### PR TITLE
Hash parameter in initialization.

### DIFF
--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -20,12 +20,12 @@ module MediaWiki
     include MediaWiki::Administration
 
     # Creates a new instance of MediaWiki::Butt.
-    # @param opts [Hash<Symbol, Any>] The options hash for configuring this instance of Butt.
-    # @option opts [String] :url The FULL wiki URL. api.php can be omitted, but it will make harsh assumptions about
+    # @param url [String] The FULL wiki URL. api.php can be omitted, but it will make harsh assumptions about
     # your wiki configuration.
+    # @param opts [Hash<Symbol, Any>] The options hash for configuring this instance of Butt.
     # @option opts [String] :custom_agent A custom User-Agent to use. Optional.
-    def initialize(opts = {})
-      @url = opts[:url] =~ /api.php$/ ? opts[:url] : "#{opts[:url]}/api.php"
+    def initialize(url, opts = {})
+      @url = url =~ /api.php$/ ? url : "#{url}/api.php"
       @client = HTTPClient.new
       @uri = URI.parse(@url)
       @logged_in = false

--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -19,21 +19,17 @@ module MediaWiki
     include MediaWiki::Edit
     include MediaWiki::Administration
 
-    # Creates a new instance of MediaWiki::Butt. To work with any
-    # MediaWiki::Butt methods, you must first create an instance of it.
-    # @param url [String] The FULL wiki URL. api.php can be omitted, but it
-    #   will make harsh assumptions about your wiki configuration.
-    # @param use_ssl [Boolean] Whether or not to use SSL. Will default to true.
-    # @param custom_agent [String] A custom User-Agent to use. Optional.
-    # @since 0.1.0
-    def initialize(url, use_ssl = true, custom_agent = nil)
-      @url = url =~ /api.php$/ ? url : "#{url}/api.php"
+    # Creates a new instance of MediaWiki::Butt.
+    # @param opts [Hash<Symbol, Any>] The options hash for configuring this instance of Butt.
+    # @option opts [String] :url The FULL wiki URL. api.php can be omitted, but it will make harsh assumptions about
+    # your wiki configuration.
+    # @option opts [String] :custom_agent A custom User-Agent to use. Optional.
+    def initialize(opts = {})
+      @url = opts[:url] =~ /api.php$/ ? opts[:url] : "#{opts[:url]}/api.php"
       @client = HTTPClient.new
       @uri = URI.parse(@url)
-      @ssl = use_ssl
       @logged_in = false
-      @custom_agent = custom_agent unless custom_agent.nil?
-      @tokens = {}
+      @custom_agent = opts[:custom_agent]
     end
 
     # Performs a generic HTTP POST action and provides the response. This


### PR DESCRIPTION
@xbony2 

I also removed the ssl parameter because we never actually used it. This will help us add more parameters to `initialize` easier, without requiring users to write the default arguments repeatedly. For example, once I make continue and limit better by setting it in butt, rather than passing it to each query, the following is what it will look like before and after:
```ruby
require 'mediawiki/butt'

# Before
butt = MediaWiki::Butt.new('http://ftb.gamepedia.com/api.php', true, nil, 500, true)

# After
butt = MediaWiki::Butt.new(url: 'http://ftb.gamepedia.com/api.php', continue: true)
```

Furthermore, it is more readable as you can immediately tell what each of those constants means.

It may be beneficial to actually make the url parameter required, and then have an additional hash parameter after that. What do you think?