### PR TITLE
Significantly improve limit stuff.

### DIFF
--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -19,13 +19,21 @@ module MediaWiki
     include MediaWiki::Edit
     include MediaWiki::Administration
 
+    # @return [Integer] The limit to give MW for queries. Defaults to 500. See MediaWiki documentation for details.
+    # Query limits are automatically capped in every helper query method, typically to 500 for users, or 5000 for
+    # bots. However, some APIs have different rate limits than that. If you need to have a specific rate limit for
+    # some API, you will need to set it before calling the query `BUTT.query_limit = 100; BUTT.some_query_method`.
+    attr_accessor :query_limit
+
     # Creates a new instance of MediaWiki::Butt.
     # @param url [String] The FULL wiki URL. api.php can be omitted, but it will make harsh assumptions about
     # your wiki configuration.
     # @param opts [Hash<Symbol, Any>] The options hash for configuring this instance of Butt.
     # @option opts [String] :custom_agent A custom User-Agent to use. Optional.
+    # @option opts [Integer] :query_limit The MW query limit. See query_limit attribute.
     def initialize(url, opts = {})
       @url = url =~ /api.php$/ ? url : "#{url}/api.php"
+      @query_limit = opts[:query_limit] || 500
       @client = HTTPClient.new
       @uri = URI.parse(@url)
       @logged_in = false

--- a/lib/mediawiki/query/lists/all.rb
+++ b/lib/mediawiki/query/lists/all.rb
@@ -3,18 +3,15 @@ module MediaWiki
     module Lists
       module All
         # Gets all categories on the entire wiki.
-        # @param limit [Int] The maximum number of categories to get. Defaults
-        #   to 500. Cannot be greater than 500 for normal users, or 5000 for
-        #   bots.
         # @see https://www.mediawiki.org/wiki/API:Allcategories MediaWiki
         #   Allcategories API Docs
         # @since 0.7.0
         # @return [Array] An array of all categories.
-        def get_all_categories(limit = 500)
+        def get_all_categories
           params = {
             action: 'query',
             list: 'allcategories',
-            aclimit: get_limited(limit)
+            aclimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -26,17 +23,15 @@ module MediaWiki
         end
 
         # Gets all the images on the wiki.
-        # @param limit [Int] The maximum number of images to get. Defaults to
-        #   500. Cannot be greater than 500 for normal users, or 5000 for bots.
         # @see https://www.mediawiki.org/wiki/API:Allimages MediaWiki Allimages
         #   API Docs
         # @since 0.7.0
         # @return [Array] An array of all images.
-        def get_all_images(limit = 500)
+        def get_all_images
           params = {
             action: 'query',
             list: 'allimages',
-            ailimit: get_limited(limit)
+            ailimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -49,17 +44,16 @@ module MediaWiki
 
         # Gets all pages within a namespace integer.
         # @param namespace [Int] The namespace ID.
-        # @param limit [Int] See #get_all_images
         # @see https://www.mediawiki.org/wiki/API:Allpages MediaWiki Allpages
         #   API Docs
         # @since 0.8.0
         # @return [Array] An array of all page titles.
-        def get_all_pages_in_namespace(namespace, limit = 500)
+        def get_all_pages_in_namespace(namespace)
           params = {
             action: 'query',
             list: 'allpages',
             apnamespace: namespace,
-            aplimit: get_limited(limit)
+            aplimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -72,16 +66,15 @@ module MediaWiki
 
         # Gets all users, or all users in a group.
         # @param group [String] The group to limit this query to.
-        # @param limit [Int] See #get_all_images.
         # @see https://www.mediawiki.org/wiki/API:Allusers MediaWiki Allusers
         #   API Docs
         # @since 0.8.0
         # @return [Hash] A hash of all users, names are keys, IDs are values.
-        def get_all_users(group = nil, limit = 500)
+        def get_all_users(group = nil)
           params = {
             action: 'query',
             list: 'allusers',
-            aulimit: get_limited(limit)
+            aulimit: get_limited(@query_limit)
           }
           params[:augroup] = group unless group.nil?
 
@@ -95,15 +88,14 @@ module MediaWiki
 
         # Gets all block IDs on the wiki. It seems like this only gets non-IP
         #   blocks, but the MediaWiki docs are a bit unclear.
-        # @param limit [Int] See #get_all_images.
         # @see https://www.mediawiki.org/wiki/API:Blocks MediaWiki Blocks API Docs
         # @since 0.8.0
         # @return [Array] All block IDs as strings.
-        def get_all_blocks(limit = 500)
+        def get_all_blocks
           params = {
             action: 'query',
             list: 'blocks',
-            bklimit: get_limited(limit),
+            bklimit: get_limited(@query_limit),
             bkprop: 'id'
           }
 
@@ -117,17 +109,16 @@ module MediaWiki
 
         # Gets all page titles that transclude a given page.
         # @param page [String] The page name.
-        # @param limit [Int] See #get_all_images.
         # @see https://www.mediawiki.org/wiki/API:Embeddedin MediaWiki Embeddedin
         #   API Docs
         # @since 0.8.0
         # @return [Array] All transcluder page titles.
-        def get_all_transcluders(page, limit = 500)
+        def get_all_transcluders(page)
           params = {
             action: 'query',
             list: 'embeddedin',
             eititle: page,
-            eilimit: get_limited(limit)
+            eilimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -139,17 +130,16 @@ module MediaWiki
         end
 
         # Gets an array of all deleted or archived files on the wiki.
-        # @param limit [Int] See #get_all_images
         # @see https://www.mediawiki.org/wiki/API:Filearchive MediaWiki
         #   Filearchive API Docs
         # @since 0.8.0
         # @return [Array] All deleted file names. These are not titles, so they do
         #   not include "File:".
-        def get_all_deleted_files(limit = 500)
+        def get_all_deleted_files
           params = {
             action: 'query',
             list: 'filearchive',
-            falimit: get_limited(limit)
+            falimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -162,16 +152,15 @@ module MediaWiki
 
         # Gets a list of all protected pages, by protection level if provided.
         # @param protection_level [String] The protection level, e.g., sysop
-        # @param limit [Int] See #get_all_images.
         # @see https://www.mediawiki.org/wiki/API:Protectedtitles MediaWiki
         #   Protectedtitles API Docs
         # @since 0.8.0
         # @return [Array] All protected page titles.
-        def get_all_protected_titles(protection_level = nil, limit = 500)
+        def get_all_protected_titles(protection_level = nil)
           params = {
             action: 'query',
             list: 'protectedtitles',
-            ptlimit: get_limited(limit)
+            ptlimit: get_limited(@query_limit)
           }
           params[:ptlevel] = protection_level unless protection_level.nil?
 

--- a/lib/mediawiki/query/lists/backlinks.rb
+++ b/lib/mediawiki/query/lists/backlinks.rb
@@ -5,19 +5,16 @@ module MediaWiki
         # Gets an array of backlinks to a given title, like
         #   Special:WhatLinksHere.
         # @param title [String] The page to get the backlinks of.
-        # @param limit [Int] The maximum number of pages to get. Defaults to
-        #   500, and cannot be greater than that unless the user is a bot. If
-        #   the user is a bot, the limit cannot be greater than 5000.
         # @see https://www.mediawiki.org/wiki/API:Backlinks MediaWiki Backlinks
         #   API Docs
         # @since 0.1.0
         # @return [Array<String>] All backlinks until the limit
-        def what_links_here(title, limit = 500)
+        def what_links_here(title)
           params = {
             action: 'query',
             list: 'backlinks',
             bltitle: title,
-            bllimit: get_limited(limit)
+            bllimit: get_limited(@query_limit)
           }
 
           ret = []
@@ -30,16 +27,15 @@ module MediaWiki
         # Gets interwiki backlinks by the prefix and title.
         # @param prefix [String] The wiki prefix, e.g., "mcw".
         # @param title [String] The title of the page on that wiki.
-        # @param limit [Int] See #what_links_here.
         # @see https://www.mediawiki.org/wiki/API:Iwbacklinks MediaWiki
         #   Iwbacklinks API Docs
         # @since 0.10.0
         # @return [Array<String>] All interwiki backlinking page titles.
-        def get_interwiki_backlinks(prefix = nil, title = nil, limit = 500)
+        def get_interwiki_backlinks(prefix = nil, title = nil)
           params = {
             action: 'query',
             list: 'iwbacklinks',
-            iwbllimit: get_limited(limit)
+            iwbllimit: get_limited(@query_limit)
           }
           params[:iwblprefix] = prefix unless prefix.nil?
           params[:iwbltitle] = title unless title.nil?
@@ -54,17 +50,16 @@ module MediaWiki
         # Gets language backlinks by the language and title.
         # @param language [String] The language code
         # @param title [String] The page title.
-        # @param limit [Int] See {#what_links_here}
         # @see https://www.mediawiki.org/wiki/API:Langlinks MediaWiki Langlinks
         #   API Docs
         # @since 0.10.0
         # @return [Array<String>] All pages that link to the language links.
-        def get_language_backlinks(language = nil, title = nil, limit = 500)
+        def get_language_backlinks(language = nil, title = nil)
           language.downcase! if language.match(/[^A-Z]*/)[0].size == 0
           params = {
             action: 'query',
             list: 'langbacklinks',
-            lbltitle: get_limited(limit)
+            lbltitle: get_limited(@query_limit)
           }
           params[:lbllang] = language unless language.nil?
           params[:lbltitle] = title unless title.nil?
@@ -81,20 +76,18 @@ module MediaWiki
         # @param list_redirects [Nil/Boolean] Set to nil to list redirects and
         #   non-redirects. Set to true to only list redirects. Set to false to
         #   only list non-redirects.
-        # @param thru_redirect [Boolean] Whether to list pages that link to a
+        # @param thru_redir [Boolean] Whether to list pages that link to a
         #   redirect of the image.
-        # @param limit [Int] See {#what_links_here}
         # @see https://www.mediawiki.org/wiki/API:Imageusage MediaWiki
         #   Imageusage API Docs
         # @since 0.10.0
         # @return [Array<String>] All page titles that fit the requirements.
-        def get_image_backlinks(title, list_redirects = nil, thru_redir = false,
-                                limit = 500)
+        def get_image_backlinks(title, list_redirects = nil, thru_redir = false)
           params = {
             action: 'query',
             list: 'imageusage',
             iutitle: title,
-            iulimit: get_limited(limit)
+            iulimit: get_limited(@query_limit)
           }
 
           params[:iufilterredir] = list_redirects.nil? ? 'all' : list_redirects
@@ -109,17 +102,16 @@ module MediaWiki
 
         # Gets all external link page titles.
         # @param url [String] The URL to get backlinks for.
-        # @param limit [Int] See {#what_links_here}
         # @see https://www.mediawiki.org/wiki/API:Exturlusage MediaWiki
         #   Exturlusage API Docs
         # @since 0.10.0
         # @return [Array<String>] All pages that link to the given URL.
         # @return [Array<Hash>] All pages that link to any external links.
-        def get_url_backlinks(url = nil, limit = 500)
+        def get_url_backlinks(url = nil)
           params = {
             action: 'query',
             list: 'exturlusage',
-            eulimit: get_limited(limit)
+            eulimit: get_limited(@query_limit)
           }
           params[:euquery] = url unless url.nil?
 

--- a/lib/mediawiki/query/lists/categories.rb
+++ b/lib/mediawiki/query/lists/categories.rb
@@ -9,9 +9,6 @@ module MediaWiki
         # @param category [String] The category title. It can include
         #   "Category:", or not, it doesn't really matter because we will add it
         #   if it is missing.
-        # @param limit [Int] The maximum number of members to get. Defaults to
-        #   500, and cannot be greater than that unless the user is a bot.
-        #   If the user is a bot, the limit cannot be greater than 5000.
         # @param type [String] The type of stuff to get. There are 3 valid
         #   values: page, file, and subcat. Separate these with a pipe
         #   character, e.g., 'page|file|subcat'.
@@ -19,12 +16,12 @@ module MediaWiki
         #   Category Members API Docs
         # @since 0.1.0
         # @return [Array] All category members until the limit
-        def get_category_members(category, limit = 500, type = 'page')
+        def get_category_members(category, type = 'page')
           params = {
             action: 'query',
             list: 'categorymembers',
             cmprop: 'title',
-            cmlimit: get_limited(limit),
+            cmlimit: get_limited(@query_limit),
             cmtype: type
           }
 
@@ -42,22 +39,20 @@ module MediaWiki
 
         # Gets the subcategories of a given category.
         # @param category [String] See {#get_category_members}
-        # @param limit [Int] See {#get_category_members}
         # @see {#get_category_members}
         # @since 0.9.0
         # @return [Array<String>] All subcategories.
-        def get_subcategories(category, limit = 500)
-          get_category_members(category, limit, 'subcat')
+        def get_subcategories(category)
+          get_category_members(category, 'subcat')
         end
 
         # Gets all of the files in a given category.
         # @param category [String] See {#get_category_members}
-        # @param limit [Int] See {#get_category_members}
         # @see {#get_category_members}
         # @since 0.9.0
         # @return [Array<String>] All files in the category.
-        def get_files_in_category(category, limit = 500)
-          get_category_members(category, limit, 'file')
+        def get_files_in_category(category)
+          get_category_members(category, 'file')
         end
       end
     end

--- a/lib/mediawiki/query/lists/log/block.rb
+++ b/lib/mediawiki/query/lists/log/block.rb
@@ -10,16 +10,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   blocked, flags, duration, expiry, blocker, comment, timestamp.
-          def get_block_log(user = nil, title = nil, start = nil, stop = nil,
-                            limit = 500)
-            response = get_log('block/block', user, title, start, stop, limit)
+          def get_block_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('block/block', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|
@@ -34,16 +32,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   blocked, flags, duration, expiry, blocker, comment, timestamp.
-          def get_reblock_log(user = nil, title = nil, start = nil, stop = nil,
-                               limit = 500)
-            response = get_log('block/reblock', user, title, start, stop, limit)
+          def get_reblock_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('block/reblock', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|
@@ -58,16 +54,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   blocked, blocker, comment, timestamp.
-          def get_unblock_log(user = nil, title = nil, start = nil, stop = nil,
-                               limit = 500)
-            response = get_log('block/unblock', user, title, start, stop, limit)
+          def get_unblock_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('block/unblock', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/delete.rb
+++ b/lib/mediawiki/query/lists/log/delete.rb
@@ -10,16 +10,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_delete_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
-            response = get_log('delete/delete', user, title, start, stop, limit)
+          def get_delete_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('delete/delete', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|
@@ -34,7 +32,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -42,8 +39,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
           def get_deletion_restore_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
-            resp = get_log('delete/restore', user, title, start, stop, limit)
+                                       stop = nil)
+            resp = get_log('delete/restore', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/import.rb
+++ b/lib/mediawiki/query/lists/log/import.rb
@@ -8,7 +8,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -16,8 +15,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp, count, interwiki_title.
           def get_interwiki_import_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
-            resp = get_log('import/interwiki', user, title, start, stop, limit)
+                                       stop = nil)
+            resp = get_log('import/interwiki', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|
@@ -32,7 +31,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -40,8 +38,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, timestamp, comment.
           def get_upload_import_log(user = nil, title = nil, start = nil,
-                                    stop = nil, limit = 500)
-            resp = get_log('import/upload', user, title, start, stop, limit)
+                                    stop = nil)
+            resp = get_log('import/upload', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/log.rb
+++ b/lib/mediawiki/query/lists/log/log.rb
@@ -141,18 +141,16 @@ module MediaWiki
         # @param title [String] The title to filter by.
         # @param start [DateTime] Where to start the log events at.
         # @param stop [DateTime] Where to end the log events.
-        # @param limit [Int] The limit, maximum 500 for users or 5000 for bots.
         # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki Logevents
         #   API Docs
         # @since 0.10.0
         # @return [JSON] The response json.
-        def get_log(action, user = nil, title = nil, start = nil, stop = nil,
-                    limit = 500)
+        def get_log(action, user = nil, title = nil, start = nil, stop = nil)
           params = {
             action: 'query',
             list: 'logevents',
             leaction: action,
-            lelimit: get_limited(limit)
+            lelimit: get_limited(@query_limit)
           }
           params[:leuser] = user unless user.nil?
           params[:letitle] = title unless title.nil?

--- a/lib/mediawiki/query/lists/log/merge.rb
+++ b/lib/mediawiki/query/lists/log/merge.rb
@@ -8,16 +8,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, destination_title, mergepoint, timestamp.
-          def get_merge_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
-            response = get_log('merge/merge', user, title, start, stop, limit)
+          def get_merge_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('merge/merge', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/move.rb
+++ b/lib/mediawiki/query/lists/log/move.rb
@@ -8,16 +8,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_move_log(user = nil, title = nil, start = nil, stop = nil,
-                           limit = 500)
-            response = get_log('move/move', user, title, start, stop, limit)
+          def get_move_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('move/move', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|
@@ -32,7 +30,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -40,8 +37,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
           def get_move_redirect_log(user = nil, title = nil, start = nil,
-                                    stop = nil, limit = 500)
-            resp = get_log('move/move_redir', user, title, start, stop, limit)
+                                    stop = nil)
+            resp = get_log('move/move_redir', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/newusers.rb
+++ b/lib/mediawiki/query/lists/log/newusers.rb
@@ -8,7 +8,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -16,9 +15,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   new_user, user, comment, timestamp.
           def get_autocreate_users_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
-            response = get_log('newusers/autocreate', user, title, start, stop,
-                               limit)
+                                       stop = nil)
+            response = get_log('newusers/autocreate', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|
@@ -33,7 +31,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -41,8 +38,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, new_user, user, comment, timestamp.
           def get_user_create2_log(user = nil, title = nil, start = nil,
-                                   stop = nil, limit = 500)
-            resp = get_log('newusers/create2', user, title, start, stop, limit)
+                                   stop = nil)
+            resp = get_log('newusers/create2', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|
@@ -57,7 +54,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -65,8 +61,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
           def get_user_create_log(user = nil, title = nil, start = nil,
-                                  stop = nil, limit = 500)
-            resp = get_log('newusers/create', user, title, start, stop, limit)
+                                  stop = nil)
+            resp = get_log('newusers/create', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/patrol.rb
+++ b/lib/mediawiki/query/lists/log/patrol.rb
@@ -8,7 +8,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -16,9 +15,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, current_revision, previous_revision,
           #   timestamp.
-          def get_patrol_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
-            response = get_log('patrol/patrol', user, title, start, stop, limit)
+          def get_patrol_log(user = nil, title = nil, start = nil, stop = nil)
+            response = get_log('patrol/patrol', user, title, start, stop)
 
             ret = []
             response['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/protect.rb
+++ b/lib/mediawiki/query/lists/log/protect.rb
@@ -8,7 +8,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -16,7 +15,7 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, description, user, comment, timestamp, details.
           def get_modify_protection_log(user = nil, title = nil, start = nil,
-                                        stop = nil, limit = 500)
+                                        stop = nil)
             response = get_log('protect/modify', user, title, start, stop,
                                limit)
 
@@ -33,7 +32,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -41,8 +39,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, old_title, user, comment, timestamp.
           def get_move_protected_log(user = nil, title = nil, start = nil,
-                                     stop = nil, limit = 500)
-            resp = get_log('protect/move_prot', user, title, start, stop, limit)
+                                     stop = nil)
+            resp = get_log('protect/move_prot', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|
@@ -57,15 +55,13 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, description, user, comment, timestamp, details.
-          def get_protect_log(user = nil, title = nil, start = nil, stop = nil,
-                              limit = 500)
+          def get_protect_log(user = nil, title = nil, start = nil, stop = nil)
             response = get_log('protect/protect', user, title, start, stop,
                                limit)
 
@@ -82,7 +78,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -90,8 +85,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
           def get_unprotect_log(user = nil, title = nil, start = nil,
-                                stop = nil, limit = 500)
-            resp = get_log('protect/unprotect', user, title, start, stop, limit)
+                                stop = nil)
+            resp = get_log('protect/unprotect', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/rights.rb
+++ b/lib/mediawiki/query/lists/log/rights.rb
@@ -9,7 +9,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -17,9 +16,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, new_rights, old_rights, comment, timestamp.
           def get_autopromotion_log(user = nil, title = nil, start = nil,
-                                     stop = nil, limit = 500)
-            resp = get_log('rights/autopromote', user, title, start, stop,
-                           limit)
+                                     stop = nil)
+            resp = get_log('rights/autopromote', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|
@@ -34,16 +32,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, to, from, new_rights, old_rights, comment, timestamp.
-          def get_rights_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
-            resp = get_log('rights/rights', user, title, start, stop, limit)
+          def get_rights_log(user = nil, title = nil, start = nil, stop = nil)
+            resp = get_log('rights/rights', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/log/upload.rb
+++ b/lib/mediawiki/query/lists/log/upload.rb
@@ -9,7 +9,6 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
@@ -17,8 +16,8 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, sha, comment, timestamp.
           def get_upload_overwrite_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
-            resp = get_log('upload/overwrite', user, title, start, stop, limit)
+                                       stop = nil)
+            resp = get_log('upload/overwrite', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|
@@ -33,16 +32,14 @@ module MediaWiki
           # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
           # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
           # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-          # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
           # @see {MediaWiki::Query::Lists::Log#get_log}
           # @see https://www.mediawiki.org/wiki/API:Logevents MediaWiki
           #   Logevents API Docs
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, sha, comment, timestamp.
-          def get_upload_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
-            resp = get_log('upload/upload', user, title, start, stop, limit)
+          def get_upload_log(user = nil, title = nil, start = nil, stop = nil)
+            resp = get_log('upload/upload', user, title, start, stop)
 
             ret = []
             resp['query']['logevents'].each do |log|

--- a/lib/mediawiki/query/lists/miscellaneous.rb
+++ b/lib/mediawiki/query/lists/miscellaneous.rb
@@ -3,20 +3,17 @@ module MediaWiki
     module Lists
       module Miscellaneous
         # Returns an array of random pages titles.
-        # @param number_of_pages [Int] The number of articles to get.
-        #   Defaults to 1. Cannot be greater than 10 for normal users,
-        #   or 20 for bots.
         # @param namespace [Int] The namespace ID. Defaults to
         #   0 (the main namespace).
         # @see https://www.mediawiki.org/wiki/API:Random MediaWiki Random API
         #   Docs
         # @since 0.2.0
         # @return [Array] All members
-        def get_random_pages(number_of_pages = 1, namespace = 0)
+        def get_random_pages(namespace = 0)
           params = {
             action: 'query',
             list: 'random',
-            rnlimit: get_limited(number_of_pages, 10, 20)
+            rnlimit: get_limited(@query_limit, 10, 20)
           }
 
           if MediaWiki::Constants::NAMESPACES.value?(namespace)
@@ -33,16 +30,14 @@ module MediaWiki
         end
 
         # Gets the valid change tags on the wiki.
-        # @param limit [Int] The maximum number of results to get. Maximum 5000
-        #   for bots and 500 for users.
         # @see https://www.mediawiki.org/wiki/API:Tags MediaWiki Tags API Docs
         # @since 0.10.0
         # @return [Array<String>] All tag names.
-        def get_tags(limit = 500)
+        def get_tags
           params = {
             action: 'query',
             list: 'tags',
-            limit: get_limited(limit)
+            limit: get_limited(@query_limit)
           }
           response = post(params)
           ret = []

--- a/lib/mediawiki/query/lists/querypage.rb
+++ b/lib/mediawiki/query/lists/querypage.rb
@@ -8,89 +8,89 @@ module MediaWiki
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostrevisions_page(limit = 500)
-          get_querypage('Mostrevisions', limit)
+        def get_mostrevisions_page
+          get_querypage('Mostrevisions')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostlinked_page(limit = 500)
-          get_querypage('Mostlinked', limit)
+        def get_mostlinked_page
+          get_querypage('Mostlinked')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostlinkedtemplates_page(limit = 500)
-          get_querypage('Mostlinkedtemplates', limit)
+        def get_mostlinkedtemplates_page
+          get_querypage('Mostlinkedtemplates')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostlinkedcategories_page(limit = 500)
-          get_querypage('Mostlinkedcategories', limit)
+        def get_mostlinkedcategories_page
+          get_querypage('Mostlinkedcategories')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostinterwikis_page(limit = 500)
-          get_querypage('Mostinterwikis', limit)
+        def get_mostinterwikis_page
+          get_querypage('Mostinterwikis')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostimages_page(limit = 500)
-          get_querypage('Mostimages', limit)
+        def get_mostimages_page
+          get_querypage('Mostimages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostcategories_page(limit = 500)
-          get_querypage('Mostcategories', limit)
+        def get_mostcategories_page
+          get_querypage('Mostcategories')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_listduplicatedfiles_page(limit = 500)
-          get_querypage('ListDuplicatedFiles', limit)
+        def get_listduplicatedfiles_page
+          get_querypage('ListDuplicatedFiles')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_listredirects_page(limit = 500)
-          get_querypage('Listredirects', limit)
+        def get_listredirects_page
+          get_querypage('Listredirects')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedtemplates_page(limit = 500)
-          get_querypage('Wantedtemplates', limit)
+        def get_wantedtemplates_page
+          get_querypage('Wantedtemplates')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedpages_page(limit = 500)
-          get_querypage('Wantedpages', limit)
+        def get_wantedpages_page
+          get_querypage('Wantedpages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedfiles_page(limit = 500)
-          get_querypage('Wantedfiles', limit)
+        def get_wantedfiles_page
+          get_querypage('Wantedfiles')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedcategories_page(limit = 500)
-          get_querypage('Wantedcategories', limit)
+        def get_wantedcategories_page
+          get_querypage('Wantedcategories')
         end
 
         # @since 0.10.0
         # @see #get_querypage
         # @return [Nil] If the user does not have the necessary rights.
-        def get_unwatchedpages_page(limit = 500)
+        def get_unwatchedpages_page
           rights = get_userrights
           if rights != false && rights.include?('unwatchedpages')
-            get_querypage('Unwatchedpages', limit)
+            get_querypage('Unwatchedpages')
           else
             return nil
           end
@@ -98,96 +98,95 @@ module MediaWiki
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_unusedtemplates_page(limit = 500)
-          get_querypage('Unusedtemplates', limit)
+        def get_unusedtemplates_page
+          get_querypage('Unusedtemplates')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_unusedcategories_page(limit = 500)
-          get_querypage('Unusedcategories', limit)
+        def get_unusedcategories_page
+          get_querypage('Unusedcategories')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_uncategorizedtemplates_page(limit = 500)
-          get_querypage('Uncategorizedtemplates', limit)
+        def get_uncategorizedtemplates_page
+          get_querypage('Uncategorizedtemplates')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_uncategorizedpages_page(limit = 500)
-          get_querypage('Uncategorizedpages', limit)
+        def get_uncategorizedpages_page
+          get_querypage('Uncategorizedpages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_uncategorizedcategories_page(limit = 500)
-          get_querypage('Uncategorizedcategories', limit)
+        def get_uncategorizedcategories_page
+          get_querypage('Uncategorizedcategories')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_shortpages_page(limit = 500)
-          get_querypage('Shortpages', limit)
+        def get_shortpages_page
+          get_querypage('Shortpages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_withoutinterwiki_page(limit = 500)
-          get_querypage('Withoutinterwiki', limit)
+        def get_withoutinterwiki_page
+          get_querypage('Withoutinterwiki')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_fewestrevisions_page(limit = 500)
-          get_querypage('Fewestrevisions', limit)
+        def get_fewestrevisions_page
+          get_querypage('Fewestrevisions')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_lonelypages_page(limit = 500)
-          get_querypage('Lonelypages', limit)
+        def get_lonelypages_page
+          get_querypage('Lonelypages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_ancientpages_page(limit = 500)
-          get_querypage('Ancientpages', limit)
+        def get_ancientpages_page
+          get_querypage('Ancientpages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_longpages_page(limit = 500)
-          get_querypage('Longpages', limit)
+        def get_longpages_page
+          get_querypage('Longpages')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_doubleredirects_page(limit = 500)
-          get_querypage('DoubleRedirects', limit)
+        def get_doubleredirects_page
+          get_querypage('DoubleRedirects')
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_brokenredirects_page(limit = 500)
-          get_querypage('BrokenRedirects', limit)
+        def get_brokenredirects_page
+          get_querypage('BrokenRedirects')
         end
 
         # Performs a QueryPage request.
         # @param page [String] The special page (not including Special:) to
         #   query.
-        # @param limit [Int] The limit.
         # @see https://www.mediawiki.org/wiki/API:Querypage MediaWiki QueryPage
         #   API Docs
         # @since 0.10.0
         # @return [Hash] The response.
-        def get_querypage(page, limit = 500)
+        def get_querypage(page)
           params = {
             action: 'query',
             list: 'querypage',
             qppage: page,
-            qplimit: get_limited(limit)
+            qplimit: get_limited(@query_limit)
           }
           response = post(params)
           ret = []

--- a/lib/mediawiki/query/lists/recent_changes.rb
+++ b/lib/mediawiki/query/lists/recent_changes.rb
@@ -8,10 +8,8 @@ module MediaWiki
 
         # Gets the RecentChanges log.
         # @param user [String] See {MediaWiki::Query::Lists::Log#get_log}
-        # @param title [String] See {MediaWiki::Query::Lists::Log#get_log}
         # @param start [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
         # @param stop [DateTime] See {MediaWiki::Query::Lists::Log#get_log}
-        # @param limit [Int] See {MediaWiki::Query::Lists::Log#get_log}
         # @see https://www.mediawiki.org/wiki/API:RecentChanges MediaWiki
         #   RecentChanges API Docs
         # @since 0.10.0
@@ -19,7 +17,7 @@ module MediaWiki
         #   type, title, revid, old_revid, rcid, user, old_length, new_length,
         #   diff_length, timestamp, comment, parsed_comment, sha, new, minor,
         #   bot.
-        def get_recent_changes(user = nil, start = nil, stop = nil, limit = 500)
+        def get_recent_changes(user = nil, start = nil, stop = nil)
           time_format = MediaWiki::Constants::TIME_FORMAT
           prop = 'user|comment|parsedcomment|timestamp|title|ids|sha1|sizes' \
                  '|redirect|flags|loginfo'
@@ -33,7 +31,7 @@ module MediaWiki
             action: 'query',
             list: 'recentchanges',
             rcprop: prop,
-            rclimit: get_limited(limit)
+            rclimit: get_limited(@query_limit)
           }
           params[:rcuser] = user unless user.nil?
           params[:rcstart] = start.strftime(time_format) unless start.nil?
@@ -83,21 +81,19 @@ module MediaWiki
         # @param user [String] See {#get_recent_changes}
         # @param start [DateTime] See {#get_recent_changes}
         # @param stop [DateTime] See {#get_recent_changes}
-        # @param limit [Int] See {#get_recent_changes}
         # @see https://www.mediawiki.org/wiki/API:Deletedrevs MediaWiki
         #   Deletedrevs API Docs
         # @since 0.10.0
         # @return [Array<Hash>] All of the changes, with the following keys:
         #   timestamp, user, comment, title.
-        def get_recent_deleted_revisions(user = nil, start = nil, stop = nil,
-                                         limit = 500)
+        def get_recent_deleted_revisions(user = nil, start = nil, stop = nil)
           time_format = MediaWiki::Constants::TIME_FORMAT
           prop = 'revid|parentid|user|comment|parsedcomment|minor|len|sh1|tags'
           params = {
             action: 'query',
             list: 'deletedrevs',
             drprop: prop,
-            limit: get_limited(limit)
+            drlimit: get_limited(@query_limit)
           }
           params[:drstart] = start.strftime(time_format) unless start.nil?
           params[:drend] = stop.strftime(time_format) unless stop.nil?

--- a/lib/mediawiki/query/lists/search.rb
+++ b/lib/mediawiki/query/lists/search.rb
@@ -58,18 +58,16 @@ module MediaWiki
 
         # Searches the wiki by a prefix.
         # @param prefix [String] The prefix.
-        # @param limit [Int] The maximum number of results to get, maximum of
-        #   100 for users and 200 for bots.
         # @see https://www.mediawiki.org/wiki/API:Prefixsearch MediaWiki
         #   Prefixsearch API Docs
         # @since 0.10.0
         # @return [Array<String>] All of the page titles that match the search.
-        def get_prefix_search(prefix, limit = 100)
+        def get_prefix_search(prefix)
           params = {
             action: 'query',
             list: 'prefixsearch',
             pssearch: prefix,
-            limit: get_limited(limit, 100, 200)
+            pslimit: get_limited(@query_limit, 100, 200)
           }
 
           response = post(params)

--- a/lib/mediawiki/query/lists/users.rb
+++ b/lib/mediawiki/query/lists/users.rb
@@ -153,19 +153,18 @@ module MediaWiki
 
         # Gets the latest contributions by the user until the limit.
         # @param user [String] The username.
-        # @param limit [Int] See #get_all_images.
         # @see https://www.mediawiki.org/wiki/API:Usercontribs MediaWiki
         #   User Contributions API Docs
         # @since 0.8.0
         # @return [Hash] Each contribution by its revid, containing the title,
         #   summary, total contribution size, and the size change relative to the
         #   previous edit.
-        def get_user_contributions(user, limit = 500)
+        def get_user_contributions(user)
           params = {
             action: 'query',
             list: 'usercontribs',
             ucuser: user,
-            uclimit: get_limited(limit),
+            uclimit: get_limited(@query_limit),
             ucprop: 'ids|title|comment|size|sizediff|flags|patrolled'
           }
 
@@ -187,16 +186,16 @@ module MediaWiki
         # Gets the user's full watchlist. If no user is provided, it will use the
         #   currently logged in user, according to the MediaWiki API.
         # @param user [String] The username.
-        # @param limit [Int] See #get_all_images.
         # @see https://www.mediawiki.org/wiki/API:Watchlist MediaWiki Watchlist
         #   API Docs
         # @since 0.8.0
         # @return [Array] All the watchlist page titles.
-        def get_full_watchlist(user = nil, limit = 500)
+        def get_full_watchlist(user = nil)
           params = {
             action: 'query',
             list: 'watchlist',
-            wlprop: 'title'
+            wlprop: 'title',
+            wllimit: get_limited(@query_limit)
           }
           params[:wluser] = user unless user.nil?
 

--- a/lib/mediawiki/query/properties/contributors.rb
+++ b/lib/mediawiki/query/properties/contributors.rb
@@ -6,28 +6,24 @@ module MediaWiki
       module Contributors
         # Gets the total amount of contributors for the given page.
         # @param title [String] The page title.
-        # @param limit [Int] The maximum number of users to get. Defaults to 500
-        #   and cannot be greater than that unless the user is a bot. If the
-        #   user is a bot, the limit cannot be greater than 5000.
         # @see get_anonymous_contributors_count
         # @see get_logged_in_contributors
         # @since 0.8.0
         # @return [Int] The number of contributors to that page.
-        def get_total_contributors(title, limit = 500)
-          anon_users = get_anonymous_contributors_count(title, limit)
-          users = get_logged_in_contributors(title, limit)
+        def get_total_contributors(title)
+          anon_users = get_anonymous_contributors_count(title)
+          users = get_logged_in_contributors(title)
 
           users.size + anon_users
         end
 
         # Gets the non-anonymous contributors for the given page.
         # @param title [String] See #get_total_contributors
-        # @param limit [Int] See #get_total_contributors
         # @see get_contributors_response
         # @since 0.8.0
         # @return [Array] All usernames for the contributors.
-        def get_logged_in_contributors(title, limit = 500)
-          response = get_contributors_response(title, limit)
+        def get_logged_in_contributors(title)
+          response = get_contributors_response(title)
           pageid = nil
           response['query']['pages'].each { |r, _| pageid = r }
           ret = []
@@ -46,17 +42,16 @@ module MediaWiki
 
         # Gets the parsed response for the contributors property.
         # @param title [String] See #get_total_contributors
-        # @param limit [Int] See #get_total_contributors
         # @see https://www.mediawiki.org/wiki/API:Contributors MediaWiki
         #   Contributors Property API Docs
         # @since 0.8.0
         # @return [JSON] See #post
-        def get_contributors_response(title, limit = 500)
+        def get_contributors_response(title)
           params = {
             action: 'query',
             prop: 'contributors',
             titles: title,
-            pclimit: get_limited(limit)
+            pclimit: get_limited(@query_limit)
           }
 
           post(params)
@@ -64,12 +59,11 @@ module MediaWiki
 
         # Gets the total number of anonymous contributors for the given page.
         # @param title [String] See #get_total_contributors
-        # @param limit [Int] See #get_total_contributors
         # @see get_contributors_response
         # @since 0.8.0
         # @return [Int] The number of anonymous contributors for the page.
-        def get_anonymous_contributors_count(title, limit = 500)
-          response = get_contributors_response(title, limit)
+        def get_anonymous_contributors_count(title)
+          response = get_contributors_response(title)
           pageid = nil
           response['query']['pages'].each { |r, _| pageid = r }
           return nil if response['query']['pages'][pageid]['missing'] == ''

--- a/lib/mediawiki/query/properties/files.rb
+++ b/lib/mediawiki/query/properties/files.rb
@@ -6,18 +6,17 @@ module MediaWiki
       module Files
         # Gets the duplicated files of the title.
         # @param title [String] The title to get duplicated files of.
-        # @param limit [Int] The maximum number of files to get.
         # @see https://www.mediawiki.org/wiki/API:Duplicatefiles MediaWiki
         #   Duplicate Files API Docs
         # @since 0.8.0
         # @return [Array] Array of all the duplicated file names.
         # @return [Nil] If there aren't any duplicated files.
-        def get_duplicated_files_of(title, limit = 500)
+        def get_duplicated_files_of(title)
           params = {
             action: 'query',
             prop: 'duplicatefiles',
             titles: title,
-            dflimit: get_limited(limit)
+            dflimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -32,17 +31,16 @@ module MediaWiki
         end
 
         # Gets all duplicated files on the wiki.
-        # @param limit [Int] The maximum number of files to get.
         # @see https://www.mediawiki.org/wiki/API:Duplicatefiles MediaWiki
         #   Duplicate Files API Docs
         # @since 0.8.0
         # @return [Array] All duplicate file titles on the wiki.
-        def get_all_duplicated_files(limit = 500)
+        def get_all_duplicated_files
           params = {
             action: 'query',
             generator: 'allimages',
             prop: 'duplicatefiles',
-            dflimit: get_limited(limit)
+            dflimit: get_limited(@query_limit)
           }
 
           response = post(params)

--- a/lib/mediawiki/query/properties/pages.rb
+++ b/lib/mediawiki/query/properties/pages.rb
@@ -87,19 +87,16 @@ module MediaWiki
 
         # Gets all the external links on a given page.
         # @param page [String] The page title.
-        # @param limit [Int] The maximum number of members to get. Defaults to
-        #   500, and cannot be greater than that unless the user is a bot.
-        #   If the user is a bot, the limit cannot be greater than 5000.
         # @see https://www.mediawiki.org/wiki/API:Extlinks MediaWiki Extlinks
         #   API Docs
         # @since 0.8.0
         # @return [Array] All external link URLs.
-        def get_external_links(page, limit = 500)
+        def get_external_links(page)
           params = {
             action: 'query',
             titles: page,
             prop: 'extlinks',
-            ellimit: get_limited(limit)
+            ellimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -324,18 +321,17 @@ module MediaWiki
 
         # Gets all of the images in the given page.
         # @param page [String] The page title.
-        # @param limit [Fixnum] See #get_external_links
         # @see https://www.mediawiki.org/wiki/API:Images MediaWiki Images API
         #   Docs
         # @since 0.8.0
         # @return [Array] All of the image titles in the page.
         # @return [Nil] If the page does not exist.
-        def get_images_in_page(page, limit = 500)
+        def get_images_in_page(page)
           params = {
             action: 'query',
             prop: 'images',
             titles: page,
-            imlimit: get_limited(limit)
+            imlimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -355,18 +351,17 @@ module MediaWiki
 
         # Gets all of the templates in the given page.
         # @param page [String] The page title.
-        # @param limit [Fixnum] See #get_external_links
         # @see https://www.mediawiki.org/wiki/API:Templates MediaWiki Templates
         #   API Docs
         # @since 0.8.0
         # @return [Array] All of the templte titles in the page.
         # @return [Nil] If the page does not exist.
-        def get_templates_in_page(page, limit = 500)
+        def get_templates_in_page(page)
           params = {
             action: 'query',
             prop: 'templates',
             titles: page,
-            tllimit: get_limited(limit)
+            tllimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -386,18 +381,17 @@ module MediaWiki
 
         # Gets all of the interwiki links on the given page.
         # @param page [String] The page title.
-        # @param limit [Fixnum] See #get_external_links.
         # @see https://www.mediawiki.org/wiki/API:Iwlinks MediaWiki Interwiki
         #   Links API Docs
         # @since 0.8.0
         # @return [Array] All interwiki link titles.
         # @return [Nil] If the page does not exist.
-        def get_interwiki_links_in_page(page, limit = 500)
+        def get_interwiki_links_in_page(page)
           params = {
             action: 'query',
             prop: 'iwlinks',
             titles: page,
-            tllimit: get_limited(limit)
+            tllimit: get_limited(@query_limit)
           }
 
           response = post(params)
@@ -419,18 +413,17 @@ module MediaWiki
         #   available in. This includes url, language name, autonym, and its
         #   title. This method does not work with the Translate extension.
         # @param page [String] The page title.
-        # @param limit [Fixnum] See #get_external_links
         # @see https://www.mediawiki.org/wiki/API:Langlinks MediaWiki Langlinks
         #   API Docs
         # @since 0.8.0
         # @return [Hash] The data described previously.
         # @return [Nil] If the page does not exist.
-        def get_other_langs_of_page(page, limit = 500)
+        def get_other_langs_of_page(page)
           params = {
             action: 'query',
             prop: 'langlinks',
             titles: page,
-            lllimit: get_limited(limit),
+            lllimit: get_limited(@query_limit),
             llprop: 'url|langname|autonym'
           }
 
@@ -456,17 +449,16 @@ module MediaWiki
 
         # Gets every single link in a page.
         # @param page [String] The page title.
-        # @param limit [Fixnum] See #get_external_links.
         # @see https://www.mediawiki.org/wiki/API:Links MediaWiki Links API Docs
         # @since 0.8.0
         # @return [Array] All link titles.
         # @return [Nil] If the page does not exist.
-        def get_all_links_in_page(page, limit = 500)
+        def get_all_links_in_page(page)
           params = {
             action: 'query',
             prop: 'links',
             titles: page,
-            pllimit: get_limited(limit)
+            pllimit: get_limited(@query_limit)
           }
 
           response = post(params)

--- a/lib/mediawiki/query/query.rb
+++ b/lib/mediawiki/query/query.rb
@@ -18,18 +18,11 @@ module MediaWiki
     # @since 0.8.0
     # @return [Int] The capped number.
     def get_limited(integer, max_user = 500, max_bot = 5000)
-      if integer > max_user
-        if user_bot?
-          if integer > max_bot
-            return max_bot
-          else
-            return integer
-          end
-        else
-          return max_user
-        end
+      return integer if integer < max_user
+      if user_bot?
+        integer > max_bot ? max_bot : integer
       else
-        return integer
+        max_user
       end
     end
   end


### PR DESCRIPTION
* Set limit in initialization, with the option to set it later as it is an accessor.
* get_recent_deleted_revisions and get_prefix_search properly send limit parameter, using their according API prefix rather than simply limit.
* Improve stylistic complexity of get_limited.

This should help us write query functions with less redundant code. Those `, limit = 500`s add up!

@xbony2 