### PR TITLE
Significantly improve limits (trial 2)

### DIFF
--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -19,13 +19,19 @@ module MediaWiki
     include MediaWiki::Edit
     include MediaWiki::Administration
 
+    attr_accessor :query_limit_default
+
     # Creates a new instance of MediaWiki::Butt.
     # @param url [String] The FULL wiki URL. api.php can be omitted, but it will make harsh assumptions about
     # your wiki configuration.
     # @param opts [Hash<Symbol, Any>] The options hash for configuring this instance of Butt.
     # @option opts [String] :custom_agent A custom User-Agent to use. Optional.
+    # @option opts [Fixnum] :query_limit_default The query limit to use if no limit parameter is explicitly given to
+    # the various query methods. In other words, if you pass a limit parameter to the valid query methods, it will
+    # use that, otherwise, it will use this. Defaults to 500.
     def initialize(url, opts = {})
       @url = url =~ /api.php$/ ? url : "#{url}/api.php"
+      @query_limit_default = opts[:query_limit_default] || 500
       @client = HTTPClient.new
       @uri = URI.parse(@url)
       @logged_in = false

--- a/lib/mediawiki/query/lists/all.rb
+++ b/lib/mediawiki/query/lists/all.rb
@@ -3,14 +3,13 @@ module MediaWiki
     module Lists
       module All
         # Gets all categories on the entire wiki.
-        # @param limit [Int] The maximum number of categories to get. Defaults
-        #   to 500. Cannot be greater than 500 for normal users, or 5000 for
-        #   bots.
+        # @param limit [Int] The maximum number of categories to get. Defaults to query_limit_default instance value.
+        # Cannot be greater than 500 for users or 5000 for bots.
         # @see https://www.mediawiki.org/wiki/API:Allcategories MediaWiki
         #   Allcategories API Docs
         # @since 0.7.0
         # @return [Array] An array of all categories.
-        def get_all_categories(limit = 500)
+        def get_all_categories(limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'allcategories',
@@ -26,13 +25,12 @@ module MediaWiki
         end
 
         # Gets all the images on the wiki.
-        # @param limit [Int] The maximum number of images to get. Defaults to
-        #   500. Cannot be greater than 500 for normal users, or 5000 for bots.
+        # @param limit [Int] See #get_all_categories.
         # @see https://www.mediawiki.org/wiki/API:Allimages MediaWiki Allimages
         #   API Docs
         # @since 0.7.0
         # @return [Array] An array of all images.
-        def get_all_images(limit = 500)
+        def get_all_images(limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'allimages',
@@ -49,12 +47,12 @@ module MediaWiki
 
         # Gets all pages within a namespace integer.
         # @param namespace [Int] The namespace ID.
-        # @param limit [Int] See #get_all_images
+        # @param limit [Int] See #get_all_categories.
         # @see https://www.mediawiki.org/wiki/API:Allpages MediaWiki Allpages
         #   API Docs
         # @since 0.8.0
         # @return [Array] An array of all page titles.
-        def get_all_pages_in_namespace(namespace, limit = 500)
+        def get_all_pages_in_namespace(namespace, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'allpages',
@@ -72,12 +70,12 @@ module MediaWiki
 
         # Gets all users, or all users in a group.
         # @param group [String] The group to limit this query to.
-        # @param limit [Int] See #get_all_images.
+        # @param limit [Int] See #get_all_categories.
         # @see https://www.mediawiki.org/wiki/API:Allusers MediaWiki Allusers
         #   API Docs
         # @since 0.8.0
         # @return [Hash] A hash of all users, names are keys, IDs are values.
-        def get_all_users(group = nil, limit = 500)
+        def get_all_users(group = nil, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'allusers',
@@ -95,11 +93,11 @@ module MediaWiki
 
         # Gets all block IDs on the wiki. It seems like this only gets non-IP
         #   blocks, but the MediaWiki docs are a bit unclear.
-        # @param limit [Int] See #get_all_images.
+        # @param limit [Int] See #get_all_categories.
         # @see https://www.mediawiki.org/wiki/API:Blocks MediaWiki Blocks API Docs
         # @since 0.8.0
         # @return [Array] All block IDs as strings.
-        def get_all_blocks(limit = 500)
+        def get_all_blocks(limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'blocks',
@@ -117,12 +115,12 @@ module MediaWiki
 
         # Gets all page titles that transclude a given page.
         # @param page [String] The page name.
-        # @param limit [Int] See #get_all_images.
+        # @param limit [Int] See #get_all_categories.
         # @see https://www.mediawiki.org/wiki/API:Embeddedin MediaWiki Embeddedin
         #   API Docs
         # @since 0.8.0
         # @return [Array] All transcluder page titles.
-        def get_all_transcluders(page, limit = 500)
+        def get_all_transcluders(page, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'embeddedin',
@@ -139,13 +137,13 @@ module MediaWiki
         end
 
         # Gets an array of all deleted or archived files on the wiki.
-        # @param limit [Int] See #get_all_images
+        # @param limit [Int] See #get_all_categories
         # @see https://www.mediawiki.org/wiki/API:Filearchive MediaWiki
         #   Filearchive API Docs
         # @since 0.8.0
         # @return [Array] All deleted file names. These are not titles, so they do
         #   not include "File:".
-        def get_all_deleted_files(limit = 500)
+        def get_all_deleted_files(limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'filearchive',
@@ -162,12 +160,12 @@ module MediaWiki
 
         # Gets a list of all protected pages, by protection level if provided.
         # @param protection_level [String] The protection level, e.g., sysop
-        # @param limit [Int] See #get_all_images.
+        # @param limit [Int] See #get_all_categories.
         # @see https://www.mediawiki.org/wiki/API:Protectedtitles MediaWiki
         #   Protectedtitles API Docs
         # @since 0.8.0
         # @return [Array] All protected page titles.
-        def get_all_protected_titles(protection_level = nil, limit = 500)
+        def get_all_protected_titles(protection_level = nil, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'protectedtitles',

--- a/lib/mediawiki/query/lists/backlinks.rb
+++ b/lib/mediawiki/query/lists/backlinks.rb
@@ -5,14 +5,13 @@ module MediaWiki
         # Gets an array of backlinks to a given title, like
         #   Special:WhatLinksHere.
         # @param title [String] The page to get the backlinks of.
-        # @param limit [Int] The maximum number of pages to get. Defaults to
-        #   500, and cannot be greater than that unless the user is a bot. If
-        #   the user is a bot, the limit cannot be greater than 5000.
+        # @param limit [Int] The maximum number of pages to get. Defaults to query_limit_default attribute. Cannot be
+        # greater than 500 for users or 5000 for bots.
         # @see https://www.mediawiki.org/wiki/API:Backlinks MediaWiki Backlinks
         #   API Docs
         # @since 0.1.0
         # @return [Array<String>] All backlinks until the limit
-        def what_links_here(title, limit = 500)
+        def what_links_here(title, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'backlinks',
@@ -35,7 +34,7 @@ module MediaWiki
         #   Iwbacklinks API Docs
         # @since 0.10.0
         # @return [Array<String>] All interwiki backlinking page titles.
-        def get_interwiki_backlinks(prefix = nil, title = nil, limit = 500)
+        def get_interwiki_backlinks(prefix = nil, title = nil, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'iwbacklinks',
@@ -59,7 +58,7 @@ module MediaWiki
         #   API Docs
         # @since 0.10.0
         # @return [Array<String>] All pages that link to the language links.
-        def get_language_backlinks(language = nil, title = nil, limit = 500)
+        def get_language_backlinks(language = nil, title = nil, limit = @query_limit_default)
           language.downcase! if language.match(/[^A-Z]*/)[0].size == 0
           params = {
             action: 'query',
@@ -88,8 +87,7 @@ module MediaWiki
         #   Imageusage API Docs
         # @since 0.10.0
         # @return [Array<String>] All page titles that fit the requirements.
-        def get_image_backlinks(title, list_redirects = nil, thru_redir = false,
-                                limit = 500)
+        def get_image_backlinks(title, list_redirects = nil, thru_redir = false, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'imageusage',
@@ -115,7 +113,7 @@ module MediaWiki
         # @since 0.10.0
         # @return [Array<String>] All pages that link to the given URL.
         # @return [Array<Hash>] All pages that link to any external links.
-        def get_url_backlinks(url = nil, limit = 500)
+        def get_url_backlinks(url = nil, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'exturlusage',

--- a/lib/mediawiki/query/lists/categories.rb
+++ b/lib/mediawiki/query/lists/categories.rb
@@ -9,9 +9,8 @@ module MediaWiki
         # @param category [String] The category title. It can include
         #   "Category:", or not, it doesn't really matter because we will add it
         #   if it is missing.
-        # @param limit [Int] The maximum number of members to get. Defaults to
-        #   500, and cannot be greater than that unless the user is a bot.
-        #   If the user is a bot, the limit cannot be greater than 5000.
+        # @param limit [Int] The maximum number of members to get. Defaults to query_limit_default attribute. Cannot 
+        # be greater than 500 for users, 5000 for bots.
         # @param type [String] The type of stuff to get. There are 3 valid
         #   values: page, file, and subcat. Separate these with a pipe
         #   character, e.g., 'page|file|subcat'.
@@ -19,7 +18,7 @@ module MediaWiki
         #   Category Members API Docs
         # @since 0.1.0
         # @return [Array] All category members until the limit
-        def get_category_members(category, limit = 500, type = 'page')
+        def get_category_members(category, limit = @query_limit_default, type = 'page')
           params = {
             action: 'query',
             list: 'categorymembers',
@@ -46,7 +45,7 @@ module MediaWiki
         # @see {#get_category_members}
         # @since 0.9.0
         # @return [Array<String>] All subcategories.
-        def get_subcategories(category, limit = 500)
+        def get_subcategories(category, limit = @query_limit_default)
           get_category_members(category, limit, 'subcat')
         end
 
@@ -56,7 +55,7 @@ module MediaWiki
         # @see {#get_category_members}
         # @since 0.9.0
         # @return [Array<String>] All files in the category.
-        def get_files_in_category(category, limit = 500)
+        def get_files_in_category(category, limit = @query_limit_default)
           get_category_members(category, limit, 'file')
         end
       end

--- a/lib/mediawiki/query/lists/log/block.rb
+++ b/lib/mediawiki/query/lists/log/block.rb
@@ -17,8 +17,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   blocked, flags, duration, expiry, blocker, comment, timestamp.
-          def get_block_log(user = nil, title = nil, start = nil, stop = nil,
-                            limit = 500)
+          def get_block_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('block/block', user, title, start, stop, limit)
 
             ret = []
@@ -41,8 +40,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   blocked, flags, duration, expiry, blocker, comment, timestamp.
-          def get_reblock_log(user = nil, title = nil, start = nil, stop = nil,
-                               limit = 500)
+          def get_reblock_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('block/reblock', user, title, start, stop, limit)
 
             ret = []
@@ -65,8 +63,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   blocked, blocker, comment, timestamp.
-          def get_unblock_log(user = nil, title = nil, start = nil, stop = nil,
-                               limit = 500)
+          def get_unblock_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('block/unblock', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/delete.rb
+++ b/lib/mediawiki/query/lists/log/delete.rb
@@ -17,8 +17,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_delete_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
+          def get_delete_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('delete/delete', user, title, start, stop, limit)
 
             ret = []
@@ -41,8 +40,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_deletion_restore_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
+          def get_deletion_restore_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('delete/restore', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/import.rb
+++ b/lib/mediawiki/query/lists/log/import.rb
@@ -15,8 +15,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp, count, interwiki_title.
-          def get_interwiki_import_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
+          def get_interwiki_import_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('import/interwiki', user, title, start, stop, limit)
 
             ret = []
@@ -39,8 +38,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, timestamp, comment.
-          def get_upload_import_log(user = nil, title = nil, start = nil,
-                                    stop = nil, limit = 500)
+          def get_upload_import_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('import/upload', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/log.rb
+++ b/lib/mediawiki/query/lists/log/log.rb
@@ -39,8 +39,7 @@ module MediaWiki
         #   API Docs
         # @since 0.10.0
         # @return [Array<Hash>] All the log events.
-        def get_overall_log(user = nil, title = nil, start = nil, stop = nil,
-                            limit = 500)
+        def get_overall_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
           time_format = MediaWiki::Constants::TIME_FORMAT
           params = {
             action: 'query',
@@ -146,8 +145,7 @@ module MediaWiki
         #   API Docs
         # @since 0.10.0
         # @return [JSON] The response json.
-        def get_log(action, user = nil, title = nil, start = nil, stop = nil,
-                    limit = 500)
+        def get_log(action, user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'logevents',

--- a/lib/mediawiki/query/lists/log/merge.rb
+++ b/lib/mediawiki/query/lists/log/merge.rb
@@ -15,8 +15,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, destination_title, mergepoint, timestamp.
-          def get_merge_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
+          def get_merge_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('merge/merge', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/move.rb
+++ b/lib/mediawiki/query/lists/log/move.rb
@@ -15,8 +15,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_move_log(user = nil, title = nil, start = nil, stop = nil,
-                           limit = 500)
+          def get_move_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('move/move', user, title, start, stop, limit)
 
             ret = []
@@ -39,8 +38,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_move_redirect_log(user = nil, title = nil, start = nil,
-                                    stop = nil, limit = 500)
+          def get_move_redirect_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('move/move_redir', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/newusers.rb
+++ b/lib/mediawiki/query/lists/log/newusers.rb
@@ -15,8 +15,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   new_user, user, comment, timestamp.
-          def get_autocreate_users_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
+          def get_autocreate_users_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('newusers/autocreate', user, title, start, stop,
                                limit)
 
@@ -40,8 +39,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, new_user, user, comment, timestamp.
-          def get_user_create2_log(user = nil, title = nil, start = nil,
-                                   stop = nil, limit = 500)
+          def get_user_create2_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('newusers/create2', user, title, start, stop, limit)
 
             ret = []
@@ -64,8 +62,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_user_create_log(user = nil, title = nil, start = nil,
-                                  stop = nil, limit = 500)
+          def get_user_create_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('newusers/create', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/patrol.rb
+++ b/lib/mediawiki/query/lists/log/patrol.rb
@@ -16,8 +16,7 @@ module MediaWiki
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, current_revision, previous_revision,
           #   timestamp.
-          def get_patrol_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
+          def get_patrol_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('patrol/patrol', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/protect.rb
+++ b/lib/mediawiki/query/lists/log/protect.rb
@@ -15,8 +15,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, description, user, comment, timestamp, details.
-          def get_modify_protection_log(user = nil, title = nil, start = nil,
-                                        stop = nil, limit = 500)
+          def get_modify_protection_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('protect/modify', user, title, start, stop,
                                limit)
 
@@ -40,8 +39,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, old_title, user, comment, timestamp.
-          def get_move_protected_log(user = nil, title = nil, start = nil,
-                                     stop = nil, limit = 500)
+          def get_move_protected_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('protect/move_prot', user, title, start, stop, limit)
 
             ret = []
@@ -64,8 +62,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, description, user, comment, timestamp, details.
-          def get_protect_log(user = nil, title = nil, start = nil, stop = nil,
-                              limit = 500)
+          def get_protect_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             response = get_log('protect/protect', user, title, start, stop,
                                limit)
 
@@ -89,8 +86,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, comment, timestamp.
-          def get_unprotect_log(user = nil, title = nil, start = nil,
-                                stop = nil, limit = 500)
+          def get_unprotect_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('protect/unprotect', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/rights.rb
+++ b/lib/mediawiki/query/lists/log/rights.rb
@@ -16,8 +16,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, new_rights, old_rights, comment, timestamp.
-          def get_autopromotion_log(user = nil, title = nil, start = nil,
-                                     stop = nil, limit = 500)
+          def get_autopromotion_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('rights/autopromote', user, title, start, stop,
                            limit)
 
@@ -41,8 +40,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, to, from, new_rights, old_rights, comment, timestamp.
-          def get_rights_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
+          def get_rights_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('rights/rights', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/log/upload.rb
+++ b/lib/mediawiki/query/lists/log/upload.rb
@@ -16,8 +16,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, sha, comment, timestamp.
-          def get_upload_overwrite_log(user = nil, title = nil, start = nil,
-                                       stop = nil, limit = 500)
+          def get_upload_overwrite_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('upload/overwrite', user, title, start, stop, limit)
 
             ret = []
@@ -40,8 +39,7 @@ module MediaWiki
           # @since 0.10.0
           # @return [Array<Hash>] The events, containing the following keys: id,
           #   title, user, sha, comment, timestamp.
-          def get_upload_log(user = nil, title = nil, start = nil, stop = nil,
-                             limit = 500)
+          def get_upload_log(user = nil, title = nil, start = nil, stop = nil, limit = @query_limit_default)
             resp = get_log('upload/upload', user, title, start, stop, limit)
 
             ret = []

--- a/lib/mediawiki/query/lists/miscellaneous.rb
+++ b/lib/mediawiki/query/lists/miscellaneous.rb
@@ -3,20 +3,19 @@ module MediaWiki
     module Lists
       module Miscellaneous
         # Returns an array of random pages titles.
-        # @param number_of_pages [Int] The number of articles to get.
-        #   Defaults to 1. Cannot be greater than 10 for normal users,
-        #   or 20 for bots.
+        # @param limit [Int] The number of articles to get. Defaults to 1. Cannot be greater than 10 for normal
+        # users, or 20 for bots. This method does *not* use the query_limit_default attribute.
         # @param namespace [Int] The namespace ID. Defaults to
         #   0 (the main namespace).
         # @see https://www.mediawiki.org/wiki/API:Random MediaWiki Random API
         #   Docs
         # @since 0.2.0
         # @return [Array] All members
-        def get_random_pages(number_of_pages = 1, namespace = 0)
+        def get_random_pages(limit = 1, namespace = 0)
           params = {
             action: 'query',
             list: 'random',
-            rnlimit: get_limited(number_of_pages, 10, 20)
+            rnlimit: get_limited(limit, 10, 20)
           }
 
           if MediaWiki::Constants::NAMESPACES.value?(namespace)
@@ -33,12 +32,11 @@ module MediaWiki
         end
 
         # Gets the valid change tags on the wiki.
-        # @param limit [Int] The maximum number of results to get. Maximum 5000
-        #   for bots and 500 for users.
+        # @param limit [Int] The maximum number of results to get. Maximum 5000 for bots and 500 for users.
         # @see https://www.mediawiki.org/wiki/API:Tags MediaWiki Tags API Docs
         # @since 0.10.0
         # @return [Array<String>] All tag names.
-        def get_tags(limit = 500)
+        def get_tags(limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'tags',

--- a/lib/mediawiki/query/lists/querypage.rb
+++ b/lib/mediawiki/query/lists/querypage.rb
@@ -8,86 +8,86 @@ module MediaWiki
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostrevisions_page(limit = 500)
+        def get_mostrevisions_page(limit = @query_limit_default)
           get_querypage('Mostrevisions', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostlinked_page(limit = 500)
+        def get_mostlinked_page(limit = @query_limit_default)
           get_querypage('Mostlinked', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostlinkedtemplates_page(limit = 500)
+        def get_mostlinkedtemplates_page(limit = @query_limit_default)
           get_querypage('Mostlinkedtemplates', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostlinkedcategories_page(limit = 500)
+        def get_mostlinkedcategories_page(limit = @query_limit_default)
           get_querypage('Mostlinkedcategories', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostinterwikis_page(limit = 500)
+        def get_mostinterwikis_page(limit = @query_limit_default)
           get_querypage('Mostinterwikis', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostimages_page(limit = 500)
+        def get_mostimages_page(limit = @query_limit_default)
           get_querypage('Mostimages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_mostcategories_page(limit = 500)
+        def get_mostcategories_page(limit = @query_limit_default)
           get_querypage('Mostcategories', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_listduplicatedfiles_page(limit = 500)
+        def get_listduplicatedfiles_page(limit = @query_limit_default)
           get_querypage('ListDuplicatedFiles', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_listredirects_page(limit = 500)
+        def get_listredirects_page(limit = @query_limit_default)
           get_querypage('Listredirects', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedtemplates_page(limit = 500)
+        def get_wantedtemplates_page(limit = @query_limit_default)
           get_querypage('Wantedtemplates', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedpages_page(limit = 500)
+        def get_wantedpages_page(limit = @query_limit_default)
           get_querypage('Wantedpages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedfiles_page(limit = 500)
+        def get_wantedfiles_page(limit = @query_limit_default)
           get_querypage('Wantedfiles', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_wantedcategories_page(limit = 500)
+        def get_wantedcategories_page(limit = @query_limit_default)
           get_querypage('Wantedcategories', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
         # @return [Nil] If the user does not have the necessary rights.
-        def get_unwatchedpages_page(limit = 500)
+        def get_unwatchedpages_page(limit = @query_limit_default)
           rights = get_userrights
           if rights != false && rights.include?('unwatchedpages')
             get_querypage('Unwatchedpages', limit)
@@ -98,79 +98,79 @@ module MediaWiki
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_unusedtemplates_page(limit = 500)
+        def get_unusedtemplates_page(limit = @query_limit_default)
           get_querypage('Unusedtemplates', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_unusedcategories_page(limit = 500)
+        def get_unusedcategories_page(limit = @query_limit_default)
           get_querypage('Unusedcategories', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_uncategorizedtemplates_page(limit = 500)
+        def get_uncategorizedtemplates_page(limit = @query_limit_default)
           get_querypage('Uncategorizedtemplates', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_uncategorizedpages_page(limit = 500)
+        def get_uncategorizedpages_page(limit = @query_limit_default)
           get_querypage('Uncategorizedpages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_uncategorizedcategories_page(limit = 500)
+        def get_uncategorizedcategories_page(limit = @query_limit_default)
           get_querypage('Uncategorizedcategories', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_shortpages_page(limit = 500)
+        def get_shortpages_page(limit = @query_limit_default)
           get_querypage('Shortpages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_withoutinterwiki_page(limit = 500)
+        def get_withoutinterwiki_page(limit = @query_limit_default)
           get_querypage('Withoutinterwiki', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_fewestrevisions_page(limit = 500)
+        def get_fewestrevisions_page(limit = @query_limit_default)
           get_querypage('Fewestrevisions', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_lonelypages_page(limit = 500)
+        def get_lonelypages_page(limit = @query_limit_default)
           get_querypage('Lonelypages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_ancientpages_page(limit = 500)
+        def get_ancientpages_page(limit = @query_limit_default)
           get_querypage('Ancientpages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_longpages_page(limit = 500)
+        def get_longpages_page(limit = @query_limit_default)
           get_querypage('Longpages', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_doubleredirects_page(limit = 500)
+        def get_doubleredirects_page(limit = @query_limit_default)
           get_querypage('DoubleRedirects', limit)
         end
 
         # @since 0.10.0
         # @see #get_querypage
-        def get_brokenredirects_page(limit = 500)
+        def get_brokenredirects_page(limit = @query_limit_default)
           get_querypage('BrokenRedirects', limit)
         end
 
@@ -182,7 +182,7 @@ module MediaWiki
         #   API Docs
         # @since 0.10.0
         # @return [Hash] The response.
-        def get_querypage(page, limit = 500)
+        def get_querypage(page, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'querypage',

--- a/lib/mediawiki/query/lists/recent_changes.rb
+++ b/lib/mediawiki/query/lists/recent_changes.rb
@@ -19,7 +19,7 @@ module MediaWiki
         #   type, title, revid, old_revid, rcid, user, old_length, new_length,
         #   diff_length, timestamp, comment, parsed_comment, sha, new, minor,
         #   bot.
-        def get_recent_changes(user = nil, start = nil, stop = nil, limit = 500)
+        def get_recent_changes(user = nil, start = nil, stop = nil, limit = @query_limit_default)
           time_format = MediaWiki::Constants::TIME_FORMAT
           prop = 'user|comment|parsedcomment|timestamp|title|ids|sha1|sizes' \
                  '|redirect|flags|loginfo'
@@ -89,15 +89,14 @@ module MediaWiki
         # @since 0.10.0
         # @return [Array<Hash>] All of the changes, with the following keys:
         #   timestamp, user, comment, title.
-        def get_recent_deleted_revisions(user = nil, start = nil, stop = nil,
-                                         limit = 500)
+        def get_recent_deleted_revisions(user = nil, start = nil, stop = nil, limit = @query_limit_default)
           time_format = MediaWiki::Constants::TIME_FORMAT
           prop = 'revid|parentid|user|comment|parsedcomment|minor|len|sh1|tags'
           params = {
             action: 'query',
             list: 'deletedrevs',
             drprop: prop,
-            limit: get_limited(limit)
+            drlimit: get_limited(limit)
           }
           params[:drstart] = start.strftime(time_format) unless start.nil?
           params[:drend] = stop.strftime(time_format) unless stop.nil?

--- a/lib/mediawiki/query/lists/search.rb
+++ b/lib/mediawiki/query/lists/search.rb
@@ -58,8 +58,8 @@ module MediaWiki
 
         # Searches the wiki by a prefix.
         # @param prefix [String] The prefix.
-        # @param limit [Int] The maximum number of results to get, maximum of
-        #   100 for users and 200 for bots.
+        # @param limit [Int] The maximum number of results to get, maximum of 100 for users and 200 for bots. This is
+        # one of the methods that does *not* use the query_limit_default attribute.
         # @see https://www.mediawiki.org/wiki/API:Prefixsearch MediaWiki
         #   Prefixsearch API Docs
         # @since 0.10.0
@@ -69,7 +69,7 @@ module MediaWiki
             action: 'query',
             list: 'prefixsearch',
             pssearch: prefix,
-            limit: get_limited(limit, 100, 200)
+            pslimit: get_limited(limit, 100, 200)
           }
 
           response = post(params)

--- a/lib/mediawiki/query/lists/users.rb
+++ b/lib/mediawiki/query/lists/users.rb
@@ -160,7 +160,7 @@ module MediaWiki
         # @return [Hash] Each contribution by its revid, containing the title,
         #   summary, total contribution size, and the size change relative to the
         #   previous edit.
-        def get_user_contributions(user, limit = 500)
+        def get_user_contributions(user, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'usercontribs',
@@ -192,11 +192,12 @@ module MediaWiki
         #   API Docs
         # @since 0.8.0
         # @return [Array] All the watchlist page titles.
-        def get_full_watchlist(user = nil, limit = 500)
+        def get_full_watchlist(user = nil, limit = @query_limit_default)
           params = {
             action: 'query',
             list: 'watchlist',
-            wlprop: 'title'
+            wlprop: 'title',
+            wllimit: get_limited(limit)
           }
           params[:wluser] = user unless user.nil?
 

--- a/lib/mediawiki/query/properties/contributors.rb
+++ b/lib/mediawiki/query/properties/contributors.rb
@@ -13,7 +13,7 @@ module MediaWiki
         # @see get_logged_in_contributors
         # @since 0.8.0
         # @return [Int] The number of contributors to that page.
-        def get_total_contributors(title, limit = 500)
+        def get_total_contributors(title, limit = @query_limit_default)
           anon_users = get_anonymous_contributors_count(title, limit)
           users = get_logged_in_contributors(title, limit)
 
@@ -26,7 +26,7 @@ module MediaWiki
         # @see get_contributors_response
         # @since 0.8.0
         # @return [Array] All usernames for the contributors.
-        def get_logged_in_contributors(title, limit = 500)
+        def get_logged_in_contributors(title, limit = @query_limit_default)
           response = get_contributors_response(title, limit)
           pageid = nil
           response['query']['pages'].each { |r, _| pageid = r }
@@ -51,7 +51,7 @@ module MediaWiki
         #   Contributors Property API Docs
         # @since 0.8.0
         # @return [JSON] See #post
-        def get_contributors_response(title, limit = 500)
+        def get_contributors_response(title, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'contributors',
@@ -68,7 +68,7 @@ module MediaWiki
         # @see get_contributors_response
         # @since 0.8.0
         # @return [Int] The number of anonymous contributors for the page.
-        def get_anonymous_contributors_count(title, limit = 500)
+        def get_anonymous_contributors_count(title, limit = @query_limit_default)
           response = get_contributors_response(title, limit)
           pageid = nil
           response['query']['pages'].each { |r, _| pageid = r }

--- a/lib/mediawiki/query/properties/files.rb
+++ b/lib/mediawiki/query/properties/files.rb
@@ -12,7 +12,7 @@ module MediaWiki
         # @since 0.8.0
         # @return [Array] Array of all the duplicated file names.
         # @return [Nil] If there aren't any duplicated files.
-        def get_duplicated_files_of(title, limit = 500)
+        def get_duplicated_files_of(title, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'duplicatefiles',
@@ -37,7 +37,7 @@ module MediaWiki
         #   Duplicate Files API Docs
         # @since 0.8.0
         # @return [Array] All duplicate file titles on the wiki.
-        def get_all_duplicated_files(limit = 500)
+        def get_all_duplicated_files(limit = @query_limit_default)
           params = {
             action: 'query',
             generator: 'allimages',

--- a/lib/mediawiki/query/properties/pages.rb
+++ b/lib/mediawiki/query/properties/pages.rb
@@ -94,7 +94,7 @@ module MediaWiki
         #   API Docs
         # @since 0.8.0
         # @return [Array] All external link URLs.
-        def get_external_links(page, limit = 500)
+        def get_external_links(page, limit = @query_limit_default)
           params = {
             action: 'query',
             titles: page,
@@ -330,7 +330,7 @@ module MediaWiki
         # @since 0.8.0
         # @return [Array] All of the image titles in the page.
         # @return [Nil] If the page does not exist.
-        def get_images_in_page(page, limit = 500)
+        def get_images_in_page(page, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'images',
@@ -361,7 +361,7 @@ module MediaWiki
         # @since 0.8.0
         # @return [Array] All of the templte titles in the page.
         # @return [Nil] If the page does not exist.
-        def get_templates_in_page(page, limit = 500)
+        def get_templates_in_page(page, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'templates',
@@ -392,7 +392,7 @@ module MediaWiki
         # @since 0.8.0
         # @return [Array] All interwiki link titles.
         # @return [Nil] If the page does not exist.
-        def get_interwiki_links_in_page(page, limit = 500)
+        def get_interwiki_links_in_page(page, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'iwlinks',
@@ -425,7 +425,7 @@ module MediaWiki
         # @since 0.8.0
         # @return [Hash] The data described previously.
         # @return [Nil] If the page does not exist.
-        def get_other_langs_of_page(page, limit = 500)
+        def get_other_langs_of_page(page, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'langlinks',
@@ -461,7 +461,7 @@ module MediaWiki
         # @since 0.8.0
         # @return [Array] All link titles.
         # @return [Nil] If the page does not exist.
-        def get_all_links_in_page(page, limit = 500)
+        def get_all_links_in_page(page, limit = @query_limit_default)
           params = {
             action: 'query',
             prop: 'links',


### PR DESCRIPTION
* Set the default limit in initialization of Butt, with the option to set it later, as it is an accessor.
* Modify most (there are a few with different limits than the typical 500, 5000) query lists to default their limit parameter to this new instance attribute.
* get_recent_revisions and get_prefix_search now properly set their limit parameter with the proper prefix.
* get_full_watchlist now actually uses its limit parameter.
* Improve method declaration line lengths.

See #28 

@xbony2 