### PR TITLE
Watch API

### DIFF
--- a/lib/mediawiki/query/query.rb
+++ b/lib/mediawiki/query/query.rb
@@ -7,30 +7,5 @@ module MediaWiki
     include MediaWiki::Query::Meta
     include MediaWiki::Query::Lists
     include MediaWiki::Query::Properties
-
-    protected
-
-    # Gets the limited version of the integer, to ensure nobody provides an int that is too large.
-    # @param integer [Fixnum] The number to limit.
-    # @param max_user [Fixnum] The maximum limit for normal users.
-    # @param max_bot [Fixnum] The maximum limit for bot users.
-    # @since 0.8.0
-    # @return [Fixnum] The capped number.
-    def get_limited(integer, max_user = 500, max_bot = 5000)
-      return integer if integer <= max_user
-
-      if user_bot?
-        integer > max_bot ? max_bot : integer
-      else
-        max_user
-      end
-    end
-
-    # Safely validates the given namespace ID, and returns 0 for the main namespace if invalid.
-    # @param namespace [Fixnum] The namespace ID.
-    # @return [Fixnum] Either the given namespace, if valid, or the main namespace ID 0 if invalid.
-    def validate_namespace(namespace)
-      MediaWiki::Constants::NAMESPACES.value?(namespace) ? namespace : 0
-    end
   end
 end

--- a/lib/mediawiki/watch.rb
+++ b/lib/mediawiki/watch.rb
@@ -1,0 +1,55 @@
+module MediaWiki
+  module Watch
+    # Adds a page or an array of pages to the current user's watchlist.
+    # @param titles [Array<String>, String] An array of page titles, or a page title as a string.
+    # @return [Hash{String => Nil, Boolean}] Keys are page titles. Nil value means the page was missing, but it
+    #   was watched anyway. True means the page was watched and it exists. False means the page was not watched.
+    # @see https://www.mediawiki.org/wiki/API:Watch MediaWiki Watch API
+    def watch(titles)
+      watch_request(titles)
+    end
+
+    # Removes a page or an array of pages from the current user's watchlist.
+    # @param (see #watch)
+    # @return (see #watch)
+    # @see https://www.mediawiki.org/wiki/API:Watch MediaWiki Watch API
+    def unwatch(titles)
+      watch_request(titles, true)
+    end
+
+    private
+
+    # Submits a watch action request.
+    # @param (see #watch)
+    # @param unwatch [Boolean] Whether the request should unwatch the pages or not.
+    # @return (see #watch)
+    def watch_request(titles, unwatch = false)
+      titles = titles.is_a?(Array) ? titles : [titles]
+      params = {
+        action: 'watch',
+        titles: titles.shift(get_limited(titles.length, 50, 500)).join('|'),
+        token: get_token('watch')
+      }
+      success_key = 'watched'
+      if unwatch
+        params[:unwatch] = 1
+        success_key = 'unwatched'
+      end
+      params[:unwatch] = 1 if unwatch
+
+      response = post(params)
+      p response
+      ret = {}
+      response['watch'].each do |entry|
+        p entry
+        title = entry['title']
+        if entry.key?(success_key)
+          ret[title] = entry.key?('missing') ? nil : true
+        else
+          ret[title] = false
+        end
+      end
+      ret
+    end
+  end
+end

--- a/lib/mediawiki/watch.rb
+++ b/lib/mediawiki/watch.rb
@@ -35,13 +35,10 @@ module MediaWiki
         params[:unwatch] = 1
         success_key = 'unwatched'
       end
-      params[:unwatch] = 1 if unwatch
 
       response = post(params)
-      p response
       ret = {}
       response['watch'].each do |entry|
-        p entry
         title = entry['title']
         if entry.key?(success_key)
           ret[title] = entry.key?('missing') ? nil : true

--- a/spec/util_test.rb
+++ b/spec/util_test.rb
@@ -29,7 +29,7 @@ describe 'MediaWiki::Utils' do
 end
 
 module MediaWiki
-  module Query
+  class Butt
     public :get_limited
     public :validate_namespace
   end


### PR DESCRIPTION
MediaWiki Watch API support. Move Query protected helper methods to Butt class so that the rest of the library can use them too.

@xbony2 please review.