### PR TITLE
Fix a couple of errors

### DIFF
--- a/lib/mediawiki/query/properties/pages.rb
+++ b/lib/mediawiki/query/properties/pages.rb
@@ -23,11 +23,7 @@ module MediaWiki
           response['query']['pages'].each { |r, _| pageid = r }
           return if response['query']['pages'][pageid]['missing'] == ''
 
-          response['query']['pages'][pageid]['categories'].each do |c|
-            ret << c['title']
-          end
-
-          ret
+          response['query']['pages'][pageid].fetch('categories', []).map { |c| c['title'] }
         end
 
         # Gets the wiki text for the given page. Returns nil if it for some reason cannot get the text, for example,

--- a/mediawiki-butt.gemspec
+++ b/mediawiki-butt.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
     'lib/mediawiki/edit.rb',
     'lib/mediawiki/exceptions.rb',
     'lib/mediawiki/utils.rb',
+    'lib/mediawiki/watch.rb',
 
     'lib/mediawiki/query/query.rb',
 


### PR DESCRIPTION
I added watch.rb to the gemspec, since it seemed to be missing (and we can't build a gem without it!).

I also fixed an error in `get_categories_in_page`, which I explained in the extended commit message for e9a5e9f, but - briefly - involved the API being lazy.