### PR TITLE
Improve edit error handling

### DIFF
--- a/lib/mediawiki/edit.rb
+++ b/lib/mediawiki/edit.rb
@@ -31,9 +31,12 @@ module MediaWiki
       response = post(params)
 
       if response.key?('edit') && response['edit'].key?('result') && response['edit']['result'] == 'Success'
-        response['edit'].fetch('newrevid', 'Unknown newrevid')
+        if response['edit'].key? 'newrevid'
+          response['edit']['newrevid']
+        elsif response['edit'].key? 'nochange'
+          'Page did not change'
       elsif response.key?('error')
-        response['error'].fetch('code', 'Unknown error')
+        response['error'].fetch('code', 'Unknown error code')
       else
         'Unknown error'
       end

--- a/lib/mediawiki/edit.rb
+++ b/lib/mediawiki/edit.rb
@@ -11,7 +11,8 @@ module MediaWiki
     #   documentation
     # @see https://www.mediawiki.org/wiki/API:Edit MediaWiki Edit API Docs
     # @since 0.2.0
-    # @return [String] The new revision ID, or if it failed, the error code.
+    # @raise [EditError] if the edit failed somehow
+    # @return [String] The new revision ID, or false if no change was made
     def edit(title, text, minor = false, bot = true, summary = nil)
       params = {
         action: 'edit',
@@ -34,11 +35,12 @@ module MediaWiki
         if response['edit'].key? 'newrevid'
           response['edit']['newrevid']
         elsif response['edit'].key? 'nochange'
-          'Page did not change'
+          false
+        end
       elsif response.key?('error')
-        response['error'].fetch('code', 'Unknown error code')
+        raise EditError.new(response['error'].fetch('code', 'Unknown error code'))
       else
-        'Unknown error'
+        raise EditError.new('Unknown error')
       end
     end
 

--- a/lib/mediawiki/edit.rb
+++ b/lib/mediawiki/edit.rb
@@ -30,7 +30,13 @@ module MediaWiki
 
       response = post(params)
 
-      response['edit']['result'] == 'Success' ? response['edit']['newrevid'] : response['error']['code']
+      if response.key?('edit') && response['edit'].key?('result') && response['edit']['result'] == 'Success'
+        response['edit'].fetch('newrevid', 'Unknown newrevid')
+      elsif response.key?('error')
+        response['error'].fetch('code', 'Unknown error')
+      else
+        'Unknown error'
+      end
     end
 
     # Creates a new page.

--- a/lib/mediawiki/exceptions.rb
+++ b/lib/mediawiki/exceptions.rb
@@ -122,5 +122,7 @@ module MediaWiki
         'An extension aborted the account creation.'
       end
     end
+
+    class EditError < StandardError; end
   end
 end


### PR DESCRIPTION
If there's an error while editing, the API won't give us an 'edit' key in the response, so we shouldn't assume the presence of one.