### PR TITLE
Support for the continuation API.

### DIFF
--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -90,6 +90,17 @@ module MediaWiki
       base_return
     end
 
+    # Helper method for query methods that return an array built from the query objects.
+    # @param params [Hash] A hash containing MediaWiki API parameters.
+    # @param
+    def query_ary(params, base_response_key, property_key)
+      p params
+      query(params) do |return_val, query|
+        p query[base_response_key]
+        query[base_response_key].each { |obj| return_val << obj[property_key] }
+      end
+    end
+
     # Gets whether the currently logged in user is a bot.
     # @param username [String] The username to check. Optional. Defaults to
     #   the currently logged in user if nil.

--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -79,8 +79,7 @@ module MediaWiki
       loop do
         result = post(params)
         yield(base_return, result['query']) if result.key?('query')
-        break unless @use_continuation
-        break unless result.key?('continue')
+        break unless @use_continuation || result.key?('continue')
         continue = result['continue']
         continue.each do |key, val|
           params[key.to_sym] = val
@@ -94,9 +93,7 @@ module MediaWiki
     # @param params [Hash] A hash containing MediaWiki API parameters.
     # @param
     def query_ary(params, base_response_key, property_key)
-      p params
       query(params) do |return_val, query|
-        p query[base_response_key]
         query[base_response_key].each { |obj| return_val << obj[property_key] }
       end
     end

--- a/lib/mediawiki/query/lists/all.rb
+++ b/lib/mediawiki/query/lists/all.rb
@@ -14,9 +14,7 @@ module MediaWiki
             aclimit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['allcategories'].each { |c| return_val << c['*'] }
-          end
+          query_ary(params, 'allcategories', '*')
         end
 
         # Gets all the images on the wiki.
@@ -30,9 +28,7 @@ module MediaWiki
             ailimit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['allimages'].each { |i| return_val << i['name'] }
-          end
+          query_ary(params, 'allimages', 'name')
         end
 
         # Gets all pages within a namespace integer.
@@ -48,9 +44,7 @@ module MediaWiki
             aplimit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['allpages'].each { |p| return_val << p['title'] }
-          end
+          query_ary(params, 'allpages', 'title')
         end
 
         # Gets all users, or all users in a group.
@@ -61,7 +55,6 @@ module MediaWiki
         # @return [Hash<String, Fixnum>] A hash of all users, names are keys, IDs are values.
         def get_all_users(group = nil, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'allusers',
             aulimit: get_limited(limit)
           }
@@ -85,9 +78,7 @@ module MediaWiki
             bkprop: 'id'
           }
 
-          query(params) do |return_val, query|
-            query['blocks'].each { |b| return_val << b['id'] }
-          end
+          query_ary(params, 'blocks', 'id')
         end
 
         # Gets all page titles that transclude a given page.
@@ -103,9 +94,7 @@ module MediaWiki
             eilimit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['embeddedin'].each { |e| return_val << e['title'] }
-          end
+          query_ary(params, 'embeddedin', 'title')
         end
 
         # Gets an array of all deleted or archived files on the wiki.
@@ -119,9 +108,7 @@ module MediaWiki
             falimit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['filearchive'].each { |f| return_val << f['name'] }
-          end
+          query_ary(params, 'filearchive', 'name')
         end
 
         # Gets a list of all protected pages, by protection level if provided.
@@ -137,9 +124,7 @@ module MediaWiki
           }
           params[:ptlevel] = protection_level unless protection_level.nil?
 
-          query(params) do |return_val, query|
-            query['protectedtitles'].each { |t| return_val << t['title'] }
-          end
+          query_ary(params, 'protectedtitles', 'title')
         end
       end
     end

--- a/lib/mediawiki/query/lists/all.rb
+++ b/lib/mediawiki/query/lists/all.rb
@@ -10,17 +10,13 @@ module MediaWiki
         # @return [Array<String>] An array of all categories.
         def get_all_categories(limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'allcategories',
             aclimit: get_limited(limit)
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['allcategories'].each { |c| ret << c['*'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['allcategories'].each { |c| return_val << c['*'] }
+          end
         end
 
         # Gets all the images on the wiki.
@@ -30,17 +26,13 @@ module MediaWiki
         # @return [Array<String>] An array of all images.
         def get_all_images(limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'allimages',
             ailimit: get_limited(limit)
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['allimages'].each { |i| ret << i['name'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['allimages'].each { |i| return_val << i['name'] }
+          end
         end
 
         # Gets all pages within a namespace integer.
@@ -51,18 +43,14 @@ module MediaWiki
         # @return [Array<String>] An array of all page titles.
         def get_all_pages_in_namespace(namespace, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'allpages',
             apnamespace: namespace,
             aplimit: get_limited(limit)
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['allpages'].each { |p| ret << p['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['allpages'].each { |p| return_val << p['title'] }
+          end
         end
 
         # Gets all users, or all users in a group.
@@ -79,12 +67,9 @@ module MediaWiki
           }
           params[:augroup] = group unless group.nil?
 
-          response = post(params)
-
-          ret = {}
-          response['query']['allusers'].each { |u| ret[u['name']] = u['userid'] }
-
-          ret
+          query(params, {}) do |return_val, query|
+            query['allusers'].each { |u| return_val[u['name']] = u['userid']}
+          end
         end
 
         # Gets all block IDs on the wiki. It seems like this only gets non-IP blocks, but the MediaWiki docs are a
@@ -95,18 +80,14 @@ module MediaWiki
         # @return [Array<Fixnum>] All block IDs as strings.
         def get_all_blocks(limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'blocks',
             bklimit: get_limited(limit),
             bkprop: 'id'
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['blocks'].each { |b| ret.push(b['id']) }
-
-          ret
+          query(params) do |return_val, query|
+            query['blocks'].each { |b| return_val << b['id'] }
+          end
         end
 
         # Gets all page titles that transclude a given page.
@@ -117,18 +98,14 @@ module MediaWiki
         # @return [Array<String>] All transcluder page titles.
         def get_all_transcluders(page, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'embeddedin',
             eititle: page,
             eilimit: get_limited(limit)
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['embeddedin'].each { |e| ret << e['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['embeddedin'].each { |e| return_val << e['title'] }
+          end
         end
 
         # Gets an array of all deleted or archived files on the wiki.
@@ -138,17 +115,13 @@ module MediaWiki
         # @return [Array<String>] All deleted file names. These are not titles, so they do not include "File:".
         def get_all_deleted_files(limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'filearchive',
             falimit: get_limited(limit)
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['filearchive'].each { |f| ret.push(f['name']) }
-
-          ret
+          query(params) do |return_val, query|
+            query['filearchive'].each { |f| return_val << f['name'] }
+          end
         end
 
         # Gets a list of all protected pages, by protection level if provided.
@@ -159,18 +132,14 @@ module MediaWiki
         # @return [Array<String>] All protected page titles.
         def get_all_protected_titles(protection_level = nil, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'protectedtitles',
             ptlimit: get_limited(limit)
           }
           params[:ptlevel] = protection_level unless protection_level.nil?
 
-          response = post(params)
-
-          ret = []
-          response['query']['protectedtitles'].each { |t| ret << t['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['protectedtitles'].each { |t| return_val << t['title'] }
+          end
         end
       end
     end

--- a/lib/mediawiki/query/lists/backlinks.rb
+++ b/lib/mediawiki/query/lists/backlinks.rb
@@ -11,7 +11,6 @@ module MediaWiki
         # @return [Array<String>] All backlinks until the limit
         def what_links_here(title, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'backlinks',
             bltitle: title,
             bllimit: get_limited(limit)
@@ -33,18 +32,15 @@ module MediaWiki
         # @return [Array<String>] All interwiki backlinking page titles.
         def get_interwiki_backlinks(prefix = nil, title = nil, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'iwbacklinks',
             iwbllimit: get_limited(limit)
           }
           params[:iwblprefix] = prefix unless prefix.nil?
           params[:iwbltitle] = title unless title.nil?
 
-          ret = []
-          response = post(params)
-          response['query']['iwbacklinks'].each { |bl| ret << bl['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['iwbacklinks'].each { |bl| return_val << bl['title'] }
+          end
         end
 
         # Gets language backlinks by the language and title.
@@ -56,18 +52,15 @@ module MediaWiki
         def get_language_backlinks(language = nil, title = nil, limit = @query_limit_default)
           language.downcase! if language.match(/[^A-Z]*/)[0].empty?
           params = {
-            action: 'query',
             list: 'langbacklinks',
             lbltitle: get_limited(limit)
           }
           params[:lbllang] = language unless language.nil?
           params[:lbltitle] = title unless title.nil?
 
-          ret = []
-          response = post(params)
-          response['query']['langbacklinks'].each { |bl| ret << bl['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['langbacklinks'].each { |bl| return_val << bl['title'] }
+          end
         end
 
         # Gets image backlinks, or the pages that use a given image.
@@ -80,7 +73,6 @@ module MediaWiki
         # @return [Array<String>] All page titles that fit the requirements.
         def get_image_backlinks(title, list_redirects = nil, thru_redir = false, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'imageusage',
             iutitle: title,
             iulimit: get_limited(limit)
@@ -89,11 +81,9 @@ module MediaWiki
           params[:iufilterredir] = list_redirects.nil? ? 'all' : list_redirects
           params[:iuredirect] = '1' if thru_redir
 
-          response = post(params)
-          ret = []
-          response['query']['imageusage'].each { |bl| ret << bl['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['imageusage'].each { |bl| return_val << bl['title'] }
+          end
         end
 
         # Gets all external link page titles.
@@ -106,27 +96,14 @@ module MediaWiki
         #   hash, url and title.
         def get_url_backlinks(url = nil, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'exturlusage',
             eulimit: get_limited(limit)
           }
-          params[:euquery] = url unless url.nil?
+          params[:euquery] = url unless url
 
-          response = post(params)
-          ret = []
-          response['query']['exturlusage'].each do |bl|
-            if url.nil?
-              hash = {
-                url: bl['url'],
-                title: bl['title']
-              }
-              ret << hash
-            else
-              ret << bl['title']
-            end
+          query(params) do |return_val, query|
+           query['exturlusage'].each { |bl| return_val << url ? bl['title'] : { url: bl['url'], title: bl['title'] } }
           end
-
-          ret
         end
       end
     end

--- a/lib/mediawiki/query/lists/backlinks.rb
+++ b/lib/mediawiki/query/lists/backlinks.rb
@@ -16,11 +16,7 @@ module MediaWiki
             bllimit: get_limited(limit)
           }
 
-          ret = []
-          response = post(params)
-          response['query']['backlinks'].each { |bl| ret << bl['title'] }
-
-          ret
+          query_ary(params, 'backlinks', 'title')
         end
 
         # Gets interwiki backlinks by the prefix and title.
@@ -38,9 +34,7 @@ module MediaWiki
           params[:iwblprefix] = prefix unless prefix.nil?
           params[:iwbltitle] = title unless title.nil?
 
-          query(params) do |return_val, query|
-            query['iwbacklinks'].each { |bl| return_val << bl['title'] }
-          end
+          query_ary(params, 'iwbacklinks', 'title')
         end
 
         # Gets language backlinks by the language and title.
@@ -58,9 +52,7 @@ module MediaWiki
           params[:lbllang] = language unless language.nil?
           params[:lbltitle] = title unless title.nil?
 
-          query(params) do |return_val, query|
-            query['langbacklinks'].each { |bl| return_val << bl['title'] }
-          end
+          query_ary(params, 'langbacklinks', 'title')
         end
 
         # Gets image backlinks, or the pages that use a given image.
@@ -77,13 +69,10 @@ module MediaWiki
             iutitle: title,
             iulimit: get_limited(limit)
           }
-
           params[:iufilterredir] = list_redirects.nil? ? 'all' : list_redirects
           params[:iuredirect] = '1' if thru_redir
 
-          query(params) do |return_val, query|
-            query['imageusage'].each { |bl| return_val << bl['title'] }
-          end
+          query_ary(params, 'imageusage', 'title')
         end
 
         # Gets all external link page titles.
@@ -99,7 +88,7 @@ module MediaWiki
             list: 'exturlusage',
             eulimit: get_limited(limit)
           }
-          params[:euquery] = url unless url
+          params[:euquery] = url if url
 
           query(params) do |return_val, query|
            query['exturlusage'].each { |bl| return_val << url ? bl['title'] : { url: bl['url'], title: bl['title'] } }

--- a/lib/mediawiki/query/lists/categories.rb
+++ b/lib/mediawiki/query/lists/categories.rb
@@ -21,9 +21,7 @@ module MediaWiki
 
           params[:cmtitle] = category =~ /[Cc]ategory:/ ? category : "Category:#{category}"
 
-          query(params) do |return_val, query|
-            query['categorymembers'].each { |cm| return_val << cm['title'] }
-          end
+          query_ary(params, 'categorymembers', 'title')
         end
 
         # Gets the subcategories of a given category.

--- a/lib/mediawiki/query/lists/categories.rb
+++ b/lib/mediawiki/query/lists/categories.rb
@@ -13,7 +13,6 @@ module MediaWiki
         # @return [Array<String>] All category members until the limit
         def get_category_members(category, limit = @query_limit_default, type = 'page')
           params = {
-            action: 'query',
             list: 'categorymembers',
             cmprop: 'title',
             cmlimit: get_limited(limit),
@@ -21,11 +20,10 @@ module MediaWiki
           }
 
           params[:cmtitle] = category =~ /[Cc]ategory:/ ? category : "Category:#{category}"
-          ret = []
-          response = post(params)
-          response['query']['categorymembers'].each { |cm| ret << cm['title'] }
 
-          ret
+          query(params) do |return_val, query|
+            query['categorymembers'].each { |cm| return_val << cm['title'] }
+          end
         end
 
         # Gets the subcategories of a given category.

--- a/lib/mediawiki/query/lists/miscellaneous.rb
+++ b/lib/mediawiki/query/lists/miscellaneous.rb
@@ -11,17 +11,14 @@ module MediaWiki
         # @return [Array<String>] All members
         def get_random_pages(limit = 1, namespace = 0)
           params = {
-            action: 'query',
             list: 'random',
             rnlimit: get_limited(limit, 10, 20),
             rnnamespace: validate_namespace(namespace)
           }
 
-          ret = []
-          responce = post(params)
-          responce['query']['random'].each { |a| ret << a['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['random'].each { |a| return_val << a['title'] }
+          end
         end
 
         # Gets the valid change tags on the wiki.
@@ -31,14 +28,13 @@ module MediaWiki
         # @return [Array<String>] All tag names.
         def get_tags(limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'tags',
             limit: get_limited(limit)
           }
-          response = post(params)
-          ret = []
-          response['query']['tags'].each { |tag| ret << tag['name'] }
-          ret
+
+          query(params) do |return_val, query|
+            query['tags'].each { |tag| return_val << tag['name'] }
+          end
         end
       end
     end

--- a/lib/mediawiki/query/lists/miscellaneous.rb
+++ b/lib/mediawiki/query/lists/miscellaneous.rb
@@ -4,7 +4,8 @@ module MediaWiki
       module Miscellaneous
         # Returns an array of random pages titles.
         # @param limit [Fixnum] The number of articles to get. Defaults to 1. Cannot be greater than 10 for normal
-        #   users, or 20 for bots. This method does *not* use the query_limit_default attribute.
+        #   users, or 20 for bots. This method does *not* use the query_limit_default attribute. This method does not
+        #   use continuation.
         # @param namespace [Fixnum] The namespace ID. Defaults to 0 (the main namespace).
         # @see https://www.mediawiki.org/wiki/API:Random MediaWiki Random API Docs
         # @since 0.2.0
@@ -16,9 +17,11 @@ module MediaWiki
             rnnamespace: validate_namespace(namespace)
           }
 
-          query(params) do |return_val, query|
-            query['random'].each { |a| return_val << a['title'] }
-          end
+          continue = @use_continuation
+          @use_continuation = false
+          ret = query_ary(params, 'random', 'title')
+          @use_continuation = continue
+          ret
         end
 
         # Gets the valid change tags on the wiki.
@@ -32,9 +35,7 @@ module MediaWiki
             limit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['tags'].each { |tag| return_val << tag['name'] }
-          end
+          query_ary(params, 'tags', 'name')
         end
       end
     end

--- a/lib/mediawiki/query/lists/querypage.rb
+++ b/lib/mediawiki/query/lists/querypage.rb
@@ -89,11 +89,7 @@ module MediaWiki
         # @return [Nil] If the user does not have the necessary rights.
         def get_unwatchedpages_page(limit = @query_limit_default)
           rights = get_userrights
-          if rights != false && rights.include?('unwatchedpages')
-            get_querypage('Unwatchedpages', limit)
-          else
-            return nil
-          end
+          rights && rights.include?('unwatchedpages') ? get_querypage('Unwatchedpages', limit) : nil
         end
 
         # @since 0.10.0
@@ -182,18 +178,14 @@ module MediaWiki
         # @return [Array<String>] All of the page titles in the querypage.
         def get_querypage(page, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'querypage',
             qppage: page,
             qplimit: get_limited(limit)
           }
-          response = post(params)
-          ret = []
-          response['query']['querypage']['results'].each do |result|
-            ret << result['title']
-          end
 
-          ret
+          query(params) do |return_val, query|
+            query['querypage']['results'].each { |result| return_val << result['title'] }
+          end
         end
       end
     end

--- a/lib/mediawiki/query/lists/search.rb
+++ b/lib/mediawiki/query/lists/search.rb
@@ -28,18 +28,14 @@ module MediaWiki
         # @return [Array<String>] The page titles that matched the search.
         def get_search_results(search_value, namespace = 0)
           params = {
-            action: 'query',
             list: 'search',
             srsearch: search_value,
             srnamespace: validate_namespace(namespace)
           }
 
-          response = post(params)
-
-          ret = []
-          response['query']['search'].each { |search| ret << search['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['search'].each { |search| return_val << search['title'] }
+          end
         end
 
         # Searches the wiki by a prefix.
@@ -51,19 +47,14 @@ module MediaWiki
         # @return [Array<String>] All of the page titles that match the search.
         def get_prefix_search(prefix, limit = 100)
           params = {
-            action: 'query',
             list: 'prefixsearch',
             pssearch: prefix,
             pslimit: get_limited(limit, 100, 200)
           }
 
-          response = post(params)
-          ret = []
-          response['query']['prefixsearch'].each do |result|
-            ret << result['title']
+          query(params) do |return_val, query|
+            query['prefixsearch'].each { |result| return_val << result['title'] }
           end
-
-          ret
         end
       end
     end

--- a/lib/mediawiki/query/lists/search.rb
+++ b/lib/mediawiki/query/lists/search.rb
@@ -33,9 +33,7 @@ module MediaWiki
             srnamespace: validate_namespace(namespace)
           }
 
-          query(params) do |return_val, query|
-            query['search'].each { |search| return_val << search['title'] }
-          end
+          query_ary(params, 'search', 'title')
         end
 
         # Searches the wiki by a prefix.
@@ -52,9 +50,7 @@ module MediaWiki
             pslimit: get_limited(limit, 100, 200)
           }
 
-          query(params) do |return_val, query|
-            query['prefixsearch'].each { |result| return_val << result['title'] }
-          end
+          query_ary(params, 'prefixsearch', 'title')
         end
       end
     end

--- a/lib/mediawiki/query/lists/users.rb
+++ b/lib/mediawiki/query/lists/users.rb
@@ -175,11 +175,9 @@ module MediaWiki
             wlprop: 'title',
             wllimit: get_limited(limit)
           }
-          params[:wluser] = user unless user
+          params[:wluser] = user if user
 
-          query(params) do |return_val, query|
-            query['watchlist'].each { |t| return_val << t['title'] }
-          end
+          query_ary(params, 'watchlist', 'title')
         end
       end
     end

--- a/lib/mediawiki/query/lists/users.rb
+++ b/lib/mediawiki/query/lists/users.rb
@@ -3,7 +3,7 @@ module MediaWiki
     module Lists
       module Users
         # Gets user information. This method should rarely be used by
-        # normal users, unless they want a huge amount of user data at once.
+        # normal users, unless they want a huge amount of usnot g data at once.
         # @param prop [String] The usprop parameter.
         # @param username [String] The username to get info for. Optional. Defaults to the currently logged in user
         # if omitted.
@@ -144,26 +144,22 @@ module MediaWiki
         # the size change relative to the previous edit.
         def get_user_contributions(user, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'usercontribs',
             ucuser: user,
             uclimit: get_limited(limit),
             ucprop: 'ids|title|comment|size|sizediff|flags|patrolled'
           }
 
-          response = post(params)
-
-          ret = {}
-          response['query']['usercontribs'].each do |item|
-            ret[item['revid']] = {
-              title: item['title'],
-              summary: item['comment'],
-              total_size: item['size'],
-              diff_size: item['sizediff']
-            }
+          query(params, {}) do |return_val, query|
+            query['usercontribs'].each do |item|
+              return_val[item['revid']] = {
+                title: item['title'],
+                summary: item['comment'],
+                total_size: item['size'],
+                diff_size: item['sizediff']
+              }
+            end
           end
-
-          ret
         end
 
         # Gets the user's full watchlist. If no user is provided, it will use the currently logged in user, according
@@ -175,19 +171,15 @@ module MediaWiki
         # @return [Array<String>] All the watchlist page titles.
         def get_full_watchlist(user = nil, limit = @query_limit_default)
           params = {
-            action: 'query',
             list: 'watchlist',
             wlprop: 'title',
             wllimit: get_limited(limit)
           }
-          params[:wluser] = user unless user.nil?
+          params[:wluser] = user unless user
 
-          response = post(params)
-
-          ret = []
-          response['query']['watchlist'].each { |t| ret << t['title'] }
-
-          ret
+          query(params) do |return_val, query|
+            query['watchlist'].each { |t| return_val << t['title'] }
+          end
         end
       end
     end

--- a/lib/mediawiki/query/properties/contributors.rb
+++ b/lib/mediawiki/query/properties/contributors.rb
@@ -61,9 +61,9 @@ module MediaWiki
         def get_anonymous_contributors_count(title, limit = @query_limit_default)
           ret = 0
 
-          get_contributors_response(title, limit) do |return_val, query|
+          get_contributors_response(title, limit) do |_, query|
             pageid = nil
-            query['pages'].each { |r, _| pageid = r }
+            query['pages'].each { |r, __| pageid = r }
             return if query['pages'][pageid].key?('missing')
             ret += query['pages'][pageid]['anoncontributors'].to_i
           end

--- a/lib/mediawiki/query/properties/contributors.rb
+++ b/lib/mediawiki/query/properties/contributors.rb
@@ -12,10 +12,12 @@ module MediaWiki
         # @see #get_logged_in_contributors
         # @since 0.8.0
         # @return [Fixnum] The number of contributors to that page.
+        # @return [Nil] If the page does not exist.
         def get_total_contributors(title, limit = @query_limit_default)
           anon_users = get_anonymous_contributors_count(title, limit)
           users = get_logged_in_contributors(title, limit)
 
+          return if users.nil?
           users.size + anon_users
         end
 
@@ -23,21 +25,14 @@ module MediaWiki
         # @param (see #get_total_contributors)
         # @see #get_contributors_response
         # @since 0.8.0
-        # @return [Array] All usernames for the contributors.
+        # @return [Array<String>] All usernames for the contributors.
         def get_logged_in_contributors(title, limit = @query_limit_default)
-          response = get_contributors_response(title, limit)
-          pageid = nil
-          response['query']['pages'].each { |r, _| pageid = r }
-          ret = []
-          if response['query']['pages'][pageid]['missing'] == ''
-            return nil
-          else
-            response['query']['pages'][pageid]['contributors'].each do |c|
-              ret.push(c['name'])
-            end
+          get_contributors_response(title, limit) do |return_val, query|
+            pageid = nil
+            query['pages'].each { |r, _| pageid = r }
+            return if query['pages'][pageid].key?('missing')
+            query['pages'][pageid]['contributors'].each { |c| return_val << c['name'] }
           end
-
-          ret
         end
 
         private
@@ -46,16 +41,15 @@ module MediaWiki
         # @param (see #get_total_contributors)
         # @see https://www.mediawiki.org/wiki/API:Contributors MediaWiki Contributors Property API Docs
         # @since 0.8.0
-        # @return [Hash] See {MediaWiki::Butt#post}
+        # @return [Hash] See {MediaWiki::Butt#query}
         def get_contributors_response(title, limit = @query_limit_default)
           params = {
-            action: 'query',
             prop: 'contributors',
             titles: title,
             pclimit: get_limited(limit)
           }
 
-          post(params)
+          query(params) { |return_val, query| yield(return_val, query) }
         end
 
         # Gets the total number of anonymous contributors for the given page.
@@ -65,12 +59,16 @@ module MediaWiki
         # @return [Fixnum] The number of anonymous contributors for the page.
         # @return [Nil] If title is not a valid page.
         def get_anonymous_contributors_count(title, limit = @query_limit_default)
-          response = get_contributors_response(title, limit)
-          pageid = nil
-          response['query']['pages'].each { |r, _| pageid = r }
-          return nil if response['query']['pages'][pageid]['missing'] == ''
+          ret = 0
 
-          response['query']['pages'][pageid]['anoncontriburors'].to_i
+          get_contributors_response(title, limit) do |return_val, query|
+            pageid = nil
+            query['pages'].each { |r, _| pageid = r }
+            return if query['pages'][pageid].key?('missing')
+            ret += query['pages'][pageid]['anoncontributors'].to_i
+          end
+
+          ret
         end
       end
     end

--- a/lib/mediawiki/query/properties/files.rb
+++ b/lib/mediawiki/query/properties/files.rb
@@ -37,9 +37,7 @@ module MediaWiki
             dflimit: get_limited(limit)
           }
 
-          query(params) do |return_val, query|
-            query['pages'].each { |_, c| return_val << c['title'] }
-          end
+          query_ary(params, 'pages', 'title')
         end
 
         # Gets the size of an image in bytes.

--- a/lib/mediawiki/query/properties/files.rb
+++ b/lib/mediawiki/query/properties/files.rb
@@ -10,24 +10,19 @@ module MediaWiki
         # @see https://www.mediawiki.org/wiki/API:Duplicatefiles MediaWiki Duplicate Files API Docs
         # @since 0.8.0
         # @return [Array<String>] Array of all the duplicated file names.
-        # @return [Nil] If there aren't any duplicated files.
         def get_duplicated_files_of(title, limit = @query_limit_default)
           params = {
-            action: 'query',
             prop: 'duplicatefiles',
             titles: title,
             dflimit: get_limited(limit)
           }
 
-          response = post(params)
-          ret = []
-          response['query']['pages'].each do |_, c|
-            return nil if c['duplicatefiles'].nil?
-            c['duplicatefiles'].each do |f|
-              ret << f['name']
+          query(params) do |return_val, query|
+            query['pages'].each do |_, c|
+              next unless c['duplicatefies']
+              c['duplicatefiles'].each { |f| return_val << f['name'] }
             end
           end
-          ret
         end
 
         # Gets all duplicated files on the wiki.
@@ -37,18 +32,14 @@ module MediaWiki
         # @return [Array<String>] All duplicate file titles on the wiki.
         def get_all_duplicated_files(limit = @query_limit_default)
           params = {
-            action: 'query',
             generator: 'allimages',
-            prop: 'duplicatefiles',
+            prop: 'duplicatedfiles',
             dflimit: get_limited(limit)
           }
 
-          response = post(params)
-          ret = []
-          response['query']['pages'].each do |_, c|
-            ret << c['title']
+          query(params) do |return_val, query|
+            query['pages'].each { |_, c| return_val << c['title'] }
           end
-          ret
         end
 
         # Gets the size of an image in bytes.


### PR DESCRIPTION
New Butt#query method. It takes the params, like post, the return value to start with (defaults to an empty array, is sometimes an empty hash, or other things), and a block. The block passes the base return value, and everything in the query key in the API response. The return values modifications persist over the continuation loop.
Continuation can be enabled by setting use_continuation to true, either by directly setting the instance attribute, or by passing that to the options in initialize.
Modify the majority of the query methods to use the new continuation API. This removes many lines of redundant code :tada:

This closes #9 finally.

@xbony2 and perhaps @APerson241 mind taking a look?