### PR TITLE
Utilize Enumerable methods instead of using each everywhere

### DIFF
--- a/lib/mediawiki/butt.rb
+++ b/lib/mediawiki/butt.rb
@@ -97,7 +97,7 @@ module MediaWiki
     # @param
     def query_ary(params, base_response_key, property_key)
       query(params) do |return_val, query|
-        query[base_response_key].each { |obj| return_val << obj[property_key] }
+        return_val.concat(query[base_response_key].collect { |obj| obj[property_key] })
       end
     end
 

--- a/lib/mediawiki/constants.rb
+++ b/lib/mediawiki/constants.rb
@@ -219,5 +219,9 @@ module MediaWiki
       # Extension:Flow
       'FLW_TOPIC'.freeze => 2600
     }.freeze
+
+    # @return [Proc] A proc that returns the missing page ID, -1. This is useful for using methods like Enumerable#find
+    #   and not creating a new Proc object for every call.
+    MISSING_PAGEID_PROC = Proc.new { '-1' }
   end
 end

--- a/lib/mediawiki/purge.rb
+++ b/lib/mediawiki/purge.rb
@@ -41,17 +41,12 @@ module MediaWiki
       params[:action] = 'purge'
       params[:titles] = titles.join('|')
 
-      response = post(params)
-
-      ret = {}
-
-      response['purge'].each do |hash|
+      post(params)['purge'].inject({}) do |result, hash|
         title = hash['title']
-        ret[title] = hash.key?('purged') && !hash.key?('missing')
+        result[title] = hash.key?('purged') && !hash.key?('missing')
         warn "Invalid purge (#{title}) #{hash['invalidreason']}" if hash.key?('invalid')
+        result
       end
-
-      ret
     end
   end
 end

--- a/lib/mediawiki/query/lists/querypage.rb
+++ b/lib/mediawiki/query/lists/querypage.rb
@@ -184,7 +184,7 @@ module MediaWiki
           }
 
           query(params) do |return_val, query|
-            query['querypage']['results'].each { |result| return_val << result['title'] }
+            return_val.concat(query['querypage']['results'].collect { |result| result['title'] })
           end
         end
       end

--- a/lib/mediawiki/query/lists/recent_changes.rb
+++ b/lib/mediawiki/query/lists/recent_changes.rb
@@ -34,9 +34,7 @@ module MediaWiki
           params[:rcstart] = start.xmlschema unless start.nil?
           params[:rcend] = stop.xmlschema unless stop.nil?
 
-          response = post(params)
-          ret = []
-          response['query']['recentchanges'].each do |change|
+          post(params)['query']['recentchanges'].collect do |change|
             old_length = change['oldlen']
             new_length = change['newlen']
             diff_length = new_length - old_length
@@ -68,10 +66,8 @@ module MediaWiki
               hash[:logid] = change['logid']
             end
 
-            ret << hash
+            hash
           end
-
-          ret
         end
 
         # Gets the recent deleted revisions.
@@ -90,9 +86,7 @@ module MediaWiki
           params[:drstart] = start.xmlschema unless start.nil?
           params[:drend] = stop.xmlschema unless stop.nil?
 
-          response = post(params)
-          ret = []
-          response['query']['deletedrevs'].each do |rev|
+          post(params)['query']['deletedrevs'].collect do |rev|
             r = rev['revisions'][0]
             hash = {
               timestamp: DateTime.xmlschema(r['timestamp']),
@@ -100,10 +94,9 @@ module MediaWiki
               comment: r['comment'],
               title: rev['title']
             }
-            ret << hash
-          end
 
-          ret
+            hash
+          end
         end
       end
     end

--- a/lib/mediawiki/query/lists/users.rb
+++ b/lib/mediawiki/query/lists/users.rb
@@ -36,19 +36,13 @@ module MediaWiki
         # @return [Array<String>] All of the user's groups.
         # @return [Boolean] False if username is nil and not logged in.
         def get_usergroups(username = nil)
-          ret = []
           if username.nil?
             return false unless @logged_in
-            info = get_userlists('groups')
-            info['query']['userinfo']['groups'].each { |i| ret << i }
+            get_userlists('groups')['query']['userinfo']['groups']
           else
             info = get_userlists('groups', username)
-            info['query']['users'].each do |i|
-              i['groups'].each { |g| ret << g }
-            end
+            info['query']['users'].collect { |i| i['groups'] }.flatten
           end
-
-          ret
         end
 
         # Gets the user rights for the user.
@@ -58,21 +52,14 @@ module MediaWiki
         # @return [Array<String>] All of the user's groups.
         # @return [Boolean] False if username is nil and not logged in.
         def get_userrights(username = nil)
-          ret = []
           if username.nil?
             return false unless @logged_in
             info = get_userlists('rights')
-            info['query']['userinfo']['rights'].each { |i| ret << i }
+            info['query']['userinfo']['rights']
           else
             info = get_userlists('rights', username)
-            info['query']['users'].each do |i|
-              i['rights'].each do |g|
-                ret << g
-              end
-            end
+            info['query']['users'].find { |hash| hash['name'] == username }['rights']
           end
-
-          ret
         end
 
         # Gets contribution count for the user.
@@ -83,17 +70,14 @@ module MediaWiki
         # @return [Boolean] False if username is nil and not logged in.
         # @return [Fixnum] The number of contributions the user has made.
         def get_contrib_count(username = nil)
-          count = nil
           if username.nil?
             return false unless @logged_in
             info = get_userlists('editcount')
-            count = info['query']['userinfo']['editcount']
+            info['query']['userinfo']['editcount']
           else
             info = get_userlists('editcount', username)
-            info['query']['users'].each { |i| count = i['editcount'] }
+            info['query']['users'].find { |hash| hash['name'] == username }['editcount']
           end
-
-          count
         end
 
         # Gets when the user registered.
@@ -104,7 +88,6 @@ module MediaWiki
         # @return [DateTime] The registration date and time as a DateTime object.
         # @return [Boolean] False when no username is provided and not logged in, or the user doesn't exist.
         def get_registration_time(username = nil)
-          time = nil
           # Do note that in Userinfo, registration is called registrationdate.
           if username.nil?
             return false unless @logged_in
@@ -112,7 +95,7 @@ module MediaWiki
             time = info['query']['userinfo']['registrationdate']
           else
             info = get_userlists('registration', username)
-            info['query']['users'].each { |i| time = i['registration'] }
+            time = info['query']['users'].find { |hash| hash['name'] == username }['registration']
           end
 
           return false if time.nil?
@@ -126,11 +109,8 @@ module MediaWiki
         # @since 0.4.0
         # @return [String] The gender. 'male', 'female', or 'unknown'.
         def get_user_gender(username)
-          gender = nil
           info = get_userlists('gender', username)
-          info['query']['users'].each { |i| gender = i['gender'] }
-
-          gender
+          info['query']['users'].find { |hash| hash['name'] == username }['gender']
         end
 
         # Gets the latest contributions by the user until the limit.

--- a/lib/mediawiki/query/meta/filerepoinfo.rb
+++ b/lib/mediawiki/query/meta/filerepoinfo.rb
@@ -41,26 +41,14 @@ module MediaWiki
         # @since 0.7.0
         # @return [Array<String>] All repository names that are marked as local.
         def get_local_filerepos
-          response = get_filerepoinfo('name|local')
-          ret = []
-          response['query']['repos'].each do |h|
-            ret << h['name'] if h.key?('local')
-          end
-
-          ret
+          get_filerepoinfo('name|local')['query']['repos'].select { |h| h.key?('local') }.collect { |h| h['name'] }
         end
 
         # Gets an array containing all repositories that aren't local.
         # @since 0.7.0
         # @return [Array<String>] All repositories that are not marked as local.
         def get_nonlocal_filerepos
-          response = get_filerepoinfo('name|local')
-          ret = []
-          response['query']['repos'].each do |h|
-            ret << h['name'] unless h.key?('local')
-          end
-
-          ret
+          get_filerepoinfo('name|local')['query']['repos'].reject { |h| h.key?('local') }.collect { |h| h['name'] }
         end
 
         # Gets the repository names and their according URLs.

--- a/lib/mediawiki/query/meta/siteinfo.rb
+++ b/lib/mediawiki/query/meta/siteinfo.rb
@@ -41,10 +41,7 @@ module MediaWiki
         # @since 0.6.0
         # @return [Array<String>] All extension names.
         def get_extensions
-          response = get_siteinfo('extensions')
-          ret = []
-          response['query']['extensions'].each { |e| ret << e['name'] }
-          ret
+           get_siteinfo('extensions')['query']['extensions'].collect { |e| e['name'] }
         end
 
         # Gets all languages and their codes.
@@ -123,12 +120,7 @@ module MediaWiki
         # @since 0.6.0
         # @return [Array<String>] All file extensions.
         def get_allowed_file_extensions
-          response = get_siteinfo('fileextensions')
-          ret = []
-          response['query']['fileextensions'].each do |e|
-            ret << e['ext']
-          end
-          ret
+          get_siteinfo('fileextensions')['query']['fileextensions'].collect { |e| e['ext'] }
         end
 
         # Gets the response for the restrictions siteinfo API. Not really for use by users, mostly for the other two
@@ -136,28 +128,21 @@ module MediaWiki
         # @since 0.6.0
         # @return [Hash<String, Array<String>>] All restriction data. See the other restriction methods.
         def get_restrictions_data
-          response = get_siteinfo('restrictions')
-          response['query']['restrictions']
+          get_siteinfo('restrictions')['query']['restrictions']
         end
 
         # Gets all restriction/protection types.
         # @since 0.6.0
         # @return [Array<String>] All protection types.
         def get_restriction_types
-          restrictions = get_restrictions_data
-          ret = []
-          restrictions['types'].each { |t| ret << t }
-          ret
+          get_restrictions_data['types']
         end
 
         # Gets all restriction/protection levels.
         # @since 0.6.0
         # @return [Array<String>] All protection levels.
         def get_restriction_levels
-          restrictions = get_restrictions_data
-          ret = []
-          restrictions['levels'].each { |l| ret << l }
-          ret
+          get_restrictions_data['levels']
         end
 
         # Gets all skins and their codes.
@@ -176,36 +161,21 @@ module MediaWiki
         # @since 0.6.0
         # @return [Array<String>] All extension tags.
         def get_extension_tags
-          response = get_siteinfo('extensiontags')
-          ret = []
-          response['query']['extensiontags'].each do |t|
-            ret << t
-          end
-          ret
+          get_siteinfo('extensiontags')['query']['extensiontags']
         end
 
         # Gets all function hooks.
         # @since 0.6.0
         # @return [Array<String>] All function hooks.
         def get_function_hooks
-          response = get_siteinfo('functionhooks')
-          ret = []
-          response['query']['functionhooks'].each do |h|
-            ret << h
-          end
-          ret
+          get_siteinfo('functionhooks')['query']['functionhooks']
         end
 
         # Gets all variables that are usable on the wiki, such as NUMBEROFPAGES.
         # @since 0.6.0
         # @return [Array<String>] All variable string values.
         def get_variables
-          response = get_siteinfo('variables')
-          ret = []
-          response['query']['variables'].each do |v|
-            ret << v
-          end
-          ret
+          get_siteinfo('variables')['query']['variables']
         end
       end
     end

--- a/lib/mediawiki/query/meta/userinfo.rb
+++ b/lib/mediawiki/query/meta/userinfo.rb
@@ -45,27 +45,19 @@ module MediaWiki
         # Gets a hash-of-arrays containing all the groups the user can add and remove people from.
         # @since 0.7.0
         # @return [Boolean] False if get_current_user_meta is false
-        # @return [Hash<String, Array<String>>] All the groups that the user can add, remove, add-self, and remove-self.
+        # @return [Hash<String, Array<String>>] All the groups that the user can :add, :remove, :addself, and
+        #   :remove-self.
         def get_changeable_groups
           response = get_current_user_meta('changeablegroups')
           return false unless response
 
-          ret = {}
-          add = []
-          remove = []
-          addself = []
-          removeself = []
           changeablegroups = response['query']['userinfo']['changeablegroups']
-          changeablegroups['add'].each { |g| add.push(g) }
-          changeablegroups['remove'].each { |g| remove.push(g) }
-          changeablegroups['add-self'].each { |g| addself.push(g) }
-          changeablegroups['remove-self'].each { |g| removeself.push(g) }
-          ret['add'] = add
-          ret['remove'] = remove
-          ret['addself'] = addself
-          ret['removeself'] = removeself
-
-          ret
+          {
+            :add => changeablegroups['add'],
+            :remove => changeablegroups['remove'],
+            :addself => changeablegroups['add-self'],
+            :removeself => changeablegroups['add-self']
+          }
         end
 
         # Gets the currently logged in user's real name.

--- a/lib/mediawiki/query/properties/contributors.rb
+++ b/lib/mediawiki/query/properties/contributors.rb
@@ -1,4 +1,5 @@
 require_relative '../query'
+require_relative '../../constants'
 
 module MediaWiki
   module Query
@@ -28,8 +29,7 @@ module MediaWiki
         # @return [Array<String>] All usernames for the contributors.
         def get_logged_in_contributors(title, limit = @query_limit_default)
           get_contributors_response(title, limit) do |return_val, query|
-            pageid = nil
-            query['pages'].each { |r, _| pageid = r }
+            pageid = query['pages'].keys.find(MediaWiki::Constants::MISSING_PAGEID_PROC) { |id| id != '-1' }
             return if query['pages'][pageid].key?('missing')
             query['pages'][pageid]['contributors'].each { |c| return_val << c['name'] }
           end
@@ -62,8 +62,7 @@ module MediaWiki
           ret = 0
 
           get_contributors_response(title, limit) do |_, query|
-            pageid = nil
-            query['pages'].each { |r, __| pageid = r }
+            pageid = query['pages'].keys.find(MediaWiki::Constants::MISSING_PAGEID_PROC) { |id| id != '-1' }
             return if query['pages'][pageid].key?('missing')
             ret += query['pages'][pageid]['anoncontributors'].to_i
           end

--- a/lib/mediawiki/query/properties/files.rb
+++ b/lib/mediawiki/query/properties/files.rb
@@ -1,4 +1,5 @@
 require_relative '../query'
+require_relative '../../constants'
 
 module MediaWiki
   module Query
@@ -82,14 +83,9 @@ module MediaWiki
           }
 
           response = post(params)
-          pageid = nil
-          response['query']['pages'].each { |r, _| pageid = r }
+          pageid = response['query']['pages'].keys.find(MediaWiki::Constants::MISSING_PAGEID_PROC) { |id| id != '-1'}
           return nil if pageid == '-1'
-          ret = {}
-          response['query']['pages'][pageid]['imageinfo'].each do |i|
-            i.each { |k, v| ret[k] = v }
-          end
-          ret
+          response['query']['pages'][pageid]['imageinfo'].reduce({}, :merge)
         end
       end
     end

--- a/lib/mediawiki/watch.rb
+++ b/lib/mediawiki/watch.rb
@@ -36,17 +36,16 @@ module MediaWiki
         success_key = 'unwatched'
       end
 
-      response = post(params)
-      ret = {}
-      response['watch'].each do |entry|
+      post(params)['watch'].inject({}) do |result, entry|
         title = entry['title']
         if entry.key?(success_key)
-          ret[title] = entry.key?('missing') ? nil : true
+          result[title] = entry.key?('missing') ? nil : true
         else
-          ret[title] = false
+          result[title] = false
         end
+
+        result
       end
-      ret
     end
   end
 end


### PR DESCRIPTION
Utilize Enumerable methods instead of lazily calling `each` wherever we can.

I did not touch the log stuff because most of it doesn't work anyway (#35).

@xbony2 