### PR TITLE
Add support for the Assert API

### DIFF
--- a/lib/mediawiki/auth.rb
+++ b/lib/mediawiki/auth.rb
@@ -50,7 +50,7 @@ module MediaWiki
           action: 'logout'
         }
 
-        post(params)
+        post(params, true, nil, true)
         @logged_in = false
 
         true

--- a/lib/mediawiki/auth.rb
+++ b/lib/mediawiki/auth.rb
@@ -22,7 +22,7 @@ module MediaWiki
       header = {}
       header['Set-Cookie'] = @cookie if @cookie
 
-      response = post(params, true, header)
+      response = post(params, true, header, true)
       result = response['login']['result']
 
       if result == 'NeedToken'

--- a/lib/mediawiki/exceptions.rb
+++ b/lib/mediawiki/exceptions.rb
@@ -3,5 +3,7 @@ module MediaWiki
     class AuthenticationError < StandardError; end
     class EditError < StandardError; end
     class BlockError < StandardError; end
+    class NotLoggedInError < StandardError; end
+    class NotBotError < StandardError; end
   end
 end

--- a/spec/util_test.rb
+++ b/spec/util_test.rb
@@ -38,15 +38,19 @@ end
 describe 'MediaWiki::Query' do
   describe '#get_limited' do
     it 'uses default maximums to limit the value' do
-      MW_BUTT_NO_URL.get_limited(500).must_equal(500)
-      MW_BUTT_NO_URL.get_limited(400).must_equal(400)
-      MW_BUTT_NO_URL.get_limited(600).must_equal(500)
+      MW_BUTT_NO_URL.stub(:user_bot?, false) do
+        MW_BUTT_NO_URL.get_limited(500).must_equal(500)
+        MW_BUTT_NO_URL.get_limited(400).must_equal(400)
+        MW_BUTT_NO_URL.get_limited(600).must_equal(500)
+      end
     end
 
     it 'uses custom user maximum values to limit the value' do
-      MW_BUTT_NO_URL.get_limited(400, 600).must_equal(400)
-      MW_BUTT_NO_URL.get_limited(600, 600).must_equal(600)
-      MW_BUTT_NO_URL.get_limited(700, 600).must_equal(600)
+      MW_BUTT_NO_URL.stub(:user_bot?, false) do
+        MW_BUTT_NO_URL.get_limited(400, 600).must_equal(400)
+        MW_BUTT_NO_URL.get_limited(600, 600).must_equal(600)
+        MW_BUTT_NO_URL.get_limited(700, 600).must_equal(600)
+      end
     end
 
     it 'limits the value while using a bot account' do


### PR DESCRIPTION
@xbony2 Please review this.

See https://www.mediawiki.org/wiki/API:Assert

You can now properly check if you are logged in and if you are a bot, and it doesn't use ugly usergroup crap!