### PR TITLE
Replace HTTPClient with Patron

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem('httpclient', '~> 2.8')
+gem('patron', '~> 0.13')
 
 group :development do
   gem('yard', '~> 0.9')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     github-markup (1.6.1)
-    httpclient (2.8.0)
     minitest (5.8.4)
+    patron (0.13.3)
     rake (11.1.2)
     redcarpet (3.3.4)
     yard (0.9.20)
@@ -13,8 +13,8 @@ PLATFORMS
 
 DEPENDENCIES
   github-markup (~> 1.6)
-  httpclient (~> 2.8)
   minitest (~> 5.8)
+  patron (~> 0.13)
   rake (~> 11.1)
   redcarpet (~> 3.3)
   yard (~> 0.9)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/FTB-Gamepedia/MediaWiki-Butt-Ruby.svg?branch=master)](https://travis-ci.org/FTB-Gamepedia/MediaWiki-Butt-Ruby)
 
 
-A basic Ruby library for the MediaWiki API, utilizing HTTPClient by Hiroshi Nakamura.
+A Ruby library for the MediaWiki API.
 
 ## Why?
 Two of the main editors at the FTB Gamepedia site found that the lack of functional Ruby Gems for MediaWiki API interactions made it difficult to interact with the wiki through IRC bots ([ESAEBSAD](https://github.com/xbony2/Experimental-Self-Aware-Electronic-Based-Space-Analyzing-Droid) and [SatanicBot](https://github.com/FTB-Gamepedia/SatanicBot)) and scripts. Some core features were either missing entirely or severely out of date in the many other MediaWiki gems, such as basic queries needed for everyday-actions like getting page contents and page backlinks.

--- a/mediawiki-butt.gemspec
+++ b/mediawiki-butt.gemspec
@@ -68,5 +68,5 @@ Gem::Specification.new do |s|
     'LICENSE.md'
   ]
 
-  s.add_runtime_dependency('httpclient', '~> 2.8')
+  s.add_runtime_dependency('patron', '~> 0.13')
 end


### PR DESCRIPTION
Patron uses libcurl, whereas HTTPClient uses its own HTTP code and Ruby's. As such, this is significantly faster (2x). Patron is also actively maintained, while HTTPClient is not.

Benchmark comparing 20 get_text calls on "Witchery" on ftb gamepedia.
```
             user       system     total     real
httpclient  0.057956   0.014032   0.071988 (3.536782)
patron      0.026605   0.007036   0.033641 (2.977440)
```