### PR TITLE
:gem: Implement token caching

### DIFF
--- a/lib/mediawiki/query/meta/meta.rb
+++ b/lib/mediawiki/query/meta/meta.rb
@@ -14,26 +14,25 @@ module MediaWiki
 
       # Obtains a token for the current user (or lack thereof) for specific actions. This uses the functionality
       # introduced in MediaWiki 1.27
-      # @param type [String, Array<String>] The type of token to get. See #TOKEN_TYPES to see the valid types. If it
-      #   is invalid, it will default to 'csrf'. If it is an array, it will join by a pipe for the API.
-      # @return [String, Hash<String => String>] Either a token or a set of tokens organized by type. If multiple
-      #   valid types are provided in the parameter, it returns a hash identical to the API response (see API docs).
+      # @param type [String] The type of token to get. See #TOKEN_TYPES to see the valid types. If it is invalid, it
+      #   will default to 'csrf'.
+      # @return [String] A token for the provided type.
       def get_token(type = 'csrf')
+        type = TOKEN_TYPES.include?(type) ? type : 'csrf'
+
+        return @tokens[type] if @tokens.key?(type)
+
         params = {
           action: 'query',
-          meta: 'tokens'
+          meta: 'tokens',
+          type: type
         }
-
-        if type.is_a?(Array)
-          type = (type - TOKEN_TYPES).empty? ? type.join('|') : 'csrf'
-        else
-          type = TOKEN_TYPES.include?(type) ? type : 'csrf'
-        end
-        params[:type] = type
 
         resp = post(params)
         tokens = resp['query']['tokens']
-        tokens.size > 1 ? tokens : tokens["#{type}token"]
+        token = tokens["#{type}token"]
+        @tokens[type] = token
+        token
       end
     end
   end

--- a/lib/mediawiki/query/meta/meta.rb
+++ b/lib/mediawiki/query/meta/meta.rb
@@ -18,7 +18,7 @@ module MediaWiki
       #   will default to 'csrf'.
       # @return [String] A token for the provided type.
       def get_token(type = 'csrf')
-        type = TOKEN_TYPES.include?(type) ? type : 'csrf'
+        type = 'csrf' unless TOKEN_TYPES.include?(type)
 
         return @tokens[type] if @tokens.key?(type)
 


### PR DESCRIPTION
This is a significant performance improvement. Rather than retrieving a new token every time `get_token` is called, we have an internal cache of our tokens for each type. For the first `badtoke`n error, we will try to retrieve a new token; subsequent `badtokens` will error (avoiding an infinite loop).

There is a feature degradation here as well, unfortunately. `get_token` used to be able to take an array of token types to get; with caching, this would be overly complicated (some tokens could be already cached, some might not, etc.), so instead the `get_token` feature now only takes a single token type. This should not be hugely significant, as I highly doubt many if any were making use of this feature.